### PR TITLE
Add inverse-nu penalty option

### DIFF
--- a/R/MST-PMDN.R
+++ b/R/MST-PMDN.R
@@ -826,7 +826,8 @@ define_mst_pmdn <- function(
 # PMDN skew t-distribution loss function
 # --------------------------------------
 
-loss_mst_pmdn <- function(output, target, nu_switch = 20, lambda_alpha = 0) {
+loss_mst_pmdn <- function(output, target, nu_switch = 20,
+                          lambda_alpha = 0, lambda_nu_inv = 0) {
   # Output must have: pi, mu, scale (Cholesky L), nu, alpha
   # target shape: [B, d]
   pi         <- output$pi         # [B, M]
@@ -881,6 +882,8 @@ loss_mst_pmdn <- function(output, target, nu_switch = 20, lambda_alpha = 0) {
   loss <- -torch_logsumexp(weighted_log_probs, dim = 2)$mean()
   # L2 penalty on final alpha values
   loss <- loss + lambda_alpha * alpha$pow(2)$mean()
+  # (1/nu)^2 penalty on degrees of freedom
+  loss <- loss + lambda_nu_inv * nu$pow(-2)$mean()
   loss
 }
 
@@ -993,6 +996,7 @@ train_mst_pmdn <- function(inputs,
                            jitter = 1e-6,
                            activation = nn_tanh,
                            lambda_alpha = 0,
+                           lambda_nu_inv = 0,
                            epochs = 500,
                            lr = 0.001,
                            batch_size = 16,
@@ -1205,7 +1209,9 @@ train_mst_pmdn <- function(inputs,
         outputs_batch <- batch[[2]]
         pred <- model(inputs_batch)
       }
-      loss <- loss_mst_pmdn(pred, outputs_batch, nu_switch = nu_switch, lambda_alpha = lambda_alpha)
+      loss <- loss_mst_pmdn(pred, outputs_batch, nu_switch = nu_switch,
+                             lambda_alpha = lambda_alpha,
+                             lambda_nu_inv = lambda_nu_inv)
       loss$backward()
       if (!is.null(max_norm)) nn_utils_clip_grad_norm_(model$parameters, max_norm)
       optimizer$step()
@@ -1231,7 +1237,9 @@ train_mst_pmdn <- function(inputs,
             outputs_batch <- batch[[2]]
             pred <- model(inputs_batch)
           }
-          loss <- loss_mst_pmdn(pred, outputs_batch, nu_switch = nu_switch, lambda_alpha = lambda_alpha)
+          loss <- loss_mst_pmdn(pred, outputs_batch, nu_switch = nu_switch,
+                                 lambda_alpha = lambda_alpha,
+                                 lambda_nu_inv = lambda_nu_inv)
           total_val_loss <- total_val_loss + loss$item()
           val_batches    <- val_batches + 1
         })

--- a/README.md
+++ b/README.md
@@ -339,7 +339,8 @@ The deep MST-PMDN implementation consists of the following key functions and mod
         *   Calculates the skewness adjustment term `log(2 * T_CDF(alpha_k^T w, df=nu_k+d))`, where `w` is proportional to `v`, using `t_cdf`.
     *   Combines component log-densities using mixture weights `pi` via `logsumexp`.
     *   Returns the mean NLL over the batch.
-    *   Optionally adds an L2 penalty on the final `alpha` values via `lambda_alpha`.
+    *   Optionally adds an L2 penalty on the final `alpha` values via `lambda_alpha`,
+        and on `(1/nu)^2` via `lambda_nu_inv`.
 
 #### Function: `sample_mst_pmdn(mdn_output, num_samples, ...)`
 
@@ -372,7 +373,7 @@ The deep MST-PMDN implementation consists of the following key functions and mod
 #### Function: `train_mst_pmdn(...)`
 
 *   **Purpose:** Manages the model training process.
-*   **Method:** Includes data loading, model/optimizer setup (with k-means init), training loop (loss calculation, backpropagation, optimization), validation, learning rate scheduling, checkpointing, and early stopping. Handles optional image inputs correctly and allows weighting an L2 penalty on `alpha` through `lambda_alpha`.
+*   **Method:** Includes data loading, model/optimizer setup (with k-means init), training loop (loss calculation, backpropagation, optimization), validation, learning rate scheduling, checkpointing, and early stopping. Handles optional image inputs correctly and allows weighting an L2 penalty on `alpha` through `lambda_alpha` and on `(1/nu)^2` through `lambda_nu_inv`.
 *   **Output:** Trained model, loss history, and training/validation indices.
 
 #### Function: `predict_mst_pmdn(model, new_inputs, ...)`

--- a/man/loss_mst_pmdn.Rd
+++ b/man/loss_mst_pmdn.Rd
@@ -2,7 +2,7 @@
 \alias{loss_mst_pmdn}
 \title{Negative Log-Likelihood Loss for MST-PMDN}
 \usage{
-loss_mst_pmdn(output, target, nu_switch = 20, lambda_alpha = 0)
+loss_mst_pmdn(output, target, nu_switch = 20, lambda_alpha = 0, lambda_nu_inv = 0)
 }
 \arguments{
   \item{output}{A list as returned by a forward pass of an \code{mst_pmdn_model}, containing at least the following named \code{\link[torch]{torch_tensor}} elements:
@@ -10,6 +10,7 @@ loss_mst_pmdn(output, target, nu_switch = 20, lambda_alpha = 0)
   \item{target}{A \code{\link[torch]{torch_tensor}} or numeric matrix of true responses, with shape \code{[batch_size, d]}.}
   \item{nu_switch}{Numeric scalar. Degrees-of-freedom threshold for switching between the \code{\link{t_cdf_fast}} and \code{\link{t_cdf_slow}} implementations of the Student t CDF.}
   \item{lambda_alpha}{Numeric scalar; L2 penalty weight applied to the final skewness parameters \code{alpha}.}
+  \item{lambda_nu_inv}{Numeric scalar; penalty weight applied to \code{(1/nu)^2}.}
 }
 \description{
 Computes the average negative log-likelihood under a mixture of multivariate skew t distributions for a batch of examples.  

--- a/man/train_mst_pmdn.Rd
+++ b/man/train_mst_pmdn.Rd
@@ -21,6 +21,7 @@ train_mst_pmdn(
   jitter                 = 1e-6,
   activation             = nn_tanh,
   lambda_alpha           = 0,
+  lambda_nu_inv          = 0,
   epochs                 = 500,
   lr                     = 0.001,
   batch_size             = 16,
@@ -59,6 +60,7 @@ train_mst_pmdn(
   \item{jitter}{Numeric; small ridge added to covariance diagonals for stability.}
   \item{activation}{Activation function for hidden layers (e.g., \code{nn_tanh}, \code{nn_relu}).}
   \item{lambda_alpha}{Numeric; weight of an L2 penalty on the final skewness parameter \code{alpha}.}
+  \item{lambda_nu_inv}{Numeric; weight of a penalty on \code{(1/nu)^2}.}
   \item{epochs}{Integer; maximum number of training epochs.}
   \item{lr}{Numeric; learning rate for the optimizer.}
   \item{batch_size}{Integer; mini-batch size.}

--- a/tests/testthat/test-nu-penalty.R
+++ b/tests/testthat/test-nu-penalty.R
@@ -1,0 +1,21 @@
+library(torch)
+source("R/MST-PMDN.R")
+
+B <- 1; M <- 1; d <- 1
+
+target <- torch_zeros(B, d)
+scale_chol <- torch_eye(d)$unsqueeze(1)$unsqueeze(1)$expand(c(B, M, d, d))
+output <- list(
+  pi = torch_ones(B, M),
+  mu = torch_zeros(B, M, d),
+  scale_chol = scale_chol,
+  nu = torch_full(c(B, M), 5),
+  alpha = torch_zeros(B, M, d)
+)
+
+loss0 <- loss_mst_pmdn(output, target, lambda_alpha = 0, lambda_nu_inv = 0)
+loss1 <- loss_mst_pmdn(output, target, lambda_alpha = 0, lambda_nu_inv = 0.5)
+penalty <- 0.5 * output$nu$pow(-2)$mean()
+
+stopifnot(abs((loss1 - loss0 - penalty)$item()) < 1e-6)
+cat("nu penalty test passed\n")


### PR DESCRIPTION
## Summary
- Allow weighting a `(1/nu)^2` penalty via new `lambda_nu_inv` in MST-PMDN loss and training functions
- Document inverse-nu regularization and update README
- Add unit test verifying inverse-nu penalty behaviour

## Testing
- ⚠️ `R -q -e "testthat::test_dir('tests/testthat')"` (missing `testthat` package)
- ✅ `R -q -f tests/testthat/test-alpha-penalty.R`
- ✅ `R -q -f tests/testthat/test-nu-penalty.R`

------
https://chatgpt.com/codex/tasks/task_e_68ba60bd927c8325bb2795a3f25c7c93