### PR TITLE
Add PyTorch MST-PMDN companion implementation

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -1,0 +1,49 @@
+# PyTorch MST-PMDN Companion
+
+This directory provides a self-contained PyTorch implementation of the
+Multivariate Skew-t Parsimonious Mixture Density Network (MST-PMDN).  The code
+follows the architecture and parameterisation of the original R package while
+replacing the Student-*t* helpers with differentiable `torch.distributions`
+primitives.
+
+## Layout
+
+```
+python/
+├── README.md                 # This document
+├── pyproject.toml            # Packaging metadata for editable installs
+├── src/mst_pmdn/             # Library sources
+│   ├── __init__.py
+│   ├── distributions.py      # Student-t CDF helpers
+│   ├── losses.py             # Negative log-likelihood
+│   ├── model.py              # MST-PMDN head
+│   ├── modules.py            # Weight-normalised linear layer
+│   ├── sampling.py           # Posterior sampling utilities
+│   ├── train.py              # Minimal training loop helper
+│   └── utils.py              # Miscellaneous helpers (gamma sampling, k-means, ...)
+└── tests/                    # PyTest-based unit tests
+    ├── __init__.py
+    ├── test_distributions.py
+    ├── test_model.py
+    ├── test_sampling.py
+    ├── test_train.py
+    └── test_utils.py
+```
+
+## Running the tests
+
+Create a virtual environment, install the package in editable mode and run the
+`pytest` suite:
+
+```bash
+cd python
+python -m venv .venv
+source .venv/bin/activate
+pip install -e .
+pytest
+```
+
+The test-suite exercises the utility helpers, verifies that the Student-*t* CDF
+uses PyTorch without falling back to approximations, checks output shapes and
+constraints, confirms sampling works on-device, and runs a miniature training
+loop to validate gradient flow.

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,0 +1,17 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "mst-pmdn"
+version = "0.1.0"
+description = "PyTorch companion implementation of the MST-PMDN model"
+authors = [{name = "MST-PMDN maintainers"}]
+dependencies = ["torch"]
+requires-python = ">=3.9"
+
+[project.optional-dependencies]
+test = ["pytest"]
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/python/src/mst_pmdn/__init__.py
+++ b/python/src/mst_pmdn/__init__.py
@@ -1,0 +1,22 @@
+"""PyTorch companion implementation of the MST-PMDN model."""
+
+from .utils import sample_gamma, build_orthogonal_matrix, init_mu_kmeans
+from .modules import WeightNormLinear, init_weight_norm
+from .distributions import log_student_t_cdf
+from .model import MSTPMDN
+from .losses import mst_pmdn_nll
+from .sampling import sample_mst_pmdn
+from .train import train_mst_pmdn
+
+__all__ = [
+    "sample_gamma",
+    "build_orthogonal_matrix",
+    "init_mu_kmeans",
+    "WeightNormLinear",
+    "init_weight_norm",
+    "log_student_t_cdf",
+    "MSTPMDN",
+    "mst_pmdn_nll",
+    "sample_mst_pmdn",
+    "train_mst_pmdn",
+]

--- a/python/src/mst_pmdn/distributions.py
+++ b/python/src/mst_pmdn/distributions.py
@@ -1,0 +1,20 @@
+"""Distributional helpers used by the MST-PMDN loss."""
+
+from __future__ import annotations
+
+import torch
+from torch import Tensor
+
+
+def student_t_cdf(z: Tensor, nu: Tensor | float) -> Tensor:
+    df = torch.as_tensor(nu, device=z.device, dtype=z.dtype)
+    if torch.any(df <= 0):
+        raise ValueError("Degrees of freedom must be positive")
+    dist = torch.distributions.StudentT(df=df)
+    return dist.cdf(z)
+
+
+def log_student_t_cdf(z: Tensor, nu: Tensor | float, clamp: float = 1e-12) -> Tensor:
+    cdf = student_t_cdf(z, nu)
+    cdf = torch.clamp(cdf, min=clamp)
+    return torch.log(cdf)

--- a/python/src/mst_pmdn/losses.py
+++ b/python/src/mst_pmdn/losses.py
@@ -1,0 +1,60 @@
+"""Loss functions for MST-PMDN."""
+
+from __future__ import annotations
+
+import math
+from typing import Mapping
+
+import torch
+from torch import Tensor
+
+from .distributions import log_student_t_cdf
+
+
+def mst_pmdn_nll(
+    output: Mapping[str, Tensor],
+    target: Tensor,
+    *,
+    lambda_alpha: float = 0.0,
+    lambda_nu_inv: float = 0.0,
+) -> Tensor:
+    """Negative log-likelihood of the skew-t mixture density network."""
+
+    pi = output["pi"]
+    mu = output["mu"]
+    scale_chol = output["scale_chol"]
+    nu = torch.clamp(output["nu"], min=1.0)
+    alpha = output["alpha"]
+
+    diff = target.unsqueeze(1) - mu
+    diff_unsq = diff.unsqueeze(-1)
+    v = torch.linalg.solve_triangular(scale_chol, diff_unsq, upper=False).squeeze(-1)
+    maha = v.pow(2).sum(dim=-1).clamp(max=1e6)
+
+    diag_L = scale_chol.diagonal(dim1=-2, dim2=-1)
+    log_det = 2 * torch.log(torch.clamp(diag_L, min=1e-12)).sum(dim=-1)
+    d = target.size(-1)
+    const = torch.tensor(math.pi, device=pi.device, dtype=pi.dtype)
+    half_nu = nu / 2
+    half_nu_plus_d = (nu + d) / 2
+    logC_t = (
+        torch.lgamma(half_nu_plus_d)
+        - torch.lgamma(half_nu)
+        - (d / 2) * torch.log(nu * const)
+        - 0.5 * log_det
+    )
+    logTail = -half_nu_plus_d * torch.log1p(torch.clamp(maha / nu, min=-1 + 1e-7, max=1e7))
+    log_pdf_t = logC_t + logTail
+
+    cterm = torch.sqrt((nu + d) / (nu + maha)).unsqueeze(-1).clamp(max=1e6)
+    w = cterm * v
+    alpha_dot_w = (alpha * w).sum(dim=-1)
+    log_skew_factor = torch.log(torch.tensor(2.0, device=pi.device, dtype=pi.dtype))
+    log_skew_factor = log_skew_factor + log_student_t_cdf(alpha_dot_w, nu + d)
+    log_skewt = log_pdf_t + log_skew_factor
+
+    weighted = torch.log(torch.clamp(pi, min=1e-12)) + log_skewt
+    loss = -torch.logsumexp(weighted, dim=1).mean()
+    loss = loss + lambda_alpha * alpha.pow(2).mean()
+    loss = loss + lambda_nu_inv * nu.pow(-2).mean()
+    return loss

--- a/python/src/mst_pmdn/model.py
+++ b/python/src/mst_pmdn/model.py
@@ -1,0 +1,367 @@
+"""Model definition for the PyTorch MST-PMDN head."""
+
+from __future__ import annotations
+
+from typing import Optional, Sequence
+
+import torch
+from torch import Tensor, nn
+import torch.nn.functional as F
+
+from .modules import WeightNormLinear
+from .utils import build_orthogonal_matrix, parse_constraint
+
+
+class MSTPMDN(nn.Module):
+    """Multivariate skew-t Parsimonious Mixture Density Network head."""
+
+    def __init__(
+        self,
+        input_dim: int,
+        output_dim: int,
+        hidden_dim: int | Sequence[int],
+        n_mixtures: int,
+        *,
+        constraint: str = "VVVNN",
+        constant_attr: str = "",
+        activation: type[nn.Module] | Sequence[type[nn.Module]] = nn.ReLU,
+        drop_hidden: float = 0.0,
+        image_module: Optional[nn.Module] = None,
+        tabular_module: Optional[nn.Module] = None,
+        fixed_nu: Optional[Sequence[Optional[float]]] = None,
+        range_nu: tuple[float, float] = (3.0, 50.0),
+        max_alpha: float = 2.5,
+        min_vol_shape: float = 1e-2,
+        min_mix_weight: float = 1e-4,
+        jitter: float = 1e-6,
+    ) -> None:
+        super().__init__()
+        self.output_dim = output_dim
+        self.n_mixtures = n_mixtures
+        self.constant_attr = constant_attr
+        self.max_alpha = max_alpha
+        self.min_vol_shape = min_vol_shape
+        self.min_mix_weight = min_mix_weight
+        self.jitter = jitter
+        self.min_nu, self.max_nu = range_nu
+        self.cfg = parse_constraint(constraint)
+        self.image_module = image_module
+        self.tabular_module = tabular_module
+
+        self._build_feature_network(
+            input_dim,
+            hidden_dim,
+            activation=activation,
+            drop_hidden=drop_hidden,
+        )
+        self._build_parameter_heads(fixed_nu)
+
+    # ------------------------------------------------------------------
+    # Network construction helpers
+    # ------------------------------------------------------------------
+    def _infer_output_dim(self, module: nn.Module, fallback: Optional[int], name: str) -> int:
+        for attr in ("output_dim", "out_features", "out_channels", "out_dim"):
+            value = getattr(module, attr, None)
+            if value is not None:
+                return int(value)
+        if isinstance(module, nn.Sequential) and len(module) > 0:
+            last = module[-1]
+            for attr in ("out_features", "out_channels"):
+                value = getattr(last, attr, None)
+                if value is not None:
+                    return int(value)
+        if fallback is None:
+            raise ValueError(
+                f"Unable to infer output dimension of {name}. "
+                "Provide a module exposing an output dimension attribute."
+            )
+        return fallback
+
+    def _build_feature_network(
+        self,
+        input_dim: int,
+        hidden_dim: int | Sequence[int],
+        *,
+        activation: type[nn.Module] | Sequence[type[nn.Module]],
+        drop_hidden: float,
+    ) -> None:
+        if self.tabular_module is None:
+            tabular_dim = input_dim
+        else:
+            tabular_dim = self._infer_output_dim(self.tabular_module, input_dim, "tabular_module")
+        total_input_dim = tabular_dim
+        if self.image_module is not None:
+            image_dim = self._infer_output_dim(self.image_module, None, "image_module")
+            total_input_dim += image_dim
+
+        if isinstance(hidden_dim, int):
+            hidden_dims: Sequence[int] = (hidden_dim,)
+        else:
+            hidden_dims = tuple(hidden_dim)
+        if len(hidden_dims) == 0 or hidden_dims == (0,):
+            self.hidden = nn.Identity()
+            self.final_hidden_dim = total_input_dim
+            return
+
+        if isinstance(activation, Sequence):
+            activations = list(activation)
+            if len(activations) != len(hidden_dims):
+                raise ValueError("Number of activation functions must match hidden layers")
+        else:
+            activations = [activation] * len(hidden_dims)
+
+        layers: list[nn.Module] = []
+        current = total_input_dim
+        for idx, (next_dim, act_cls) in enumerate(zip(hidden_dims, activations)):
+            layers.append(nn.Linear(current, next_dim))
+            if idx < len(hidden_dims) - 1:
+                layers.append(nn.BatchNorm1d(next_dim))
+                layers.append(act_cls())
+                if drop_hidden > 0:
+                    layers.append(nn.Dropout(drop_hidden))
+            current = next_dim
+        self.hidden = nn.Sequential(*layers)
+        self.final_hidden_dim = current
+
+    def _build_parameter_heads(self, fixed_nu: Optional[Sequence[Optional[float]]]) -> None:
+        d = self.output_dim
+        cfg = self.cfg
+        const = self.constant_attr
+
+        if "x" in const:
+            self.pi = nn.Parameter(torch.ones(self.n_mixtures) / self.n_mixtures)
+        else:
+            self.fc_pi = WeightNormLinear(self.final_hidden_dim, self.n_mixtures)
+
+        if "m" in const:
+            self.mu = nn.Parameter(torch.randn(self.n_mixtures, d))
+        else:
+            self.fc_mu = WeightNormLinear(self.final_hidden_dim, self.n_mixtures * d)
+
+        volume_size = 1 if cfg.volume_shared else self.n_mixtures
+        if "L" in const:
+            self.L_param = nn.Parameter(torch.zeros(volume_size))
+        else:
+            self.fc_L = WeightNormLinear(self.final_hidden_dim, volume_size)
+
+        if not cfg.shape_identity:
+            shape_size = d if cfg.shape_shared else self.n_mixtures * d
+            if "A" in const:
+                self.A_param = nn.Parameter(0.1 * torch.randn(shape_size))
+            else:
+                self.fc_A = WeightNormLinear(self.final_hidden_dim, shape_size)
+
+        self.r = d * (d - 1) // 2
+        if not cfg.orientation_identity:
+            orient_size = self.r if cfg.orientation_shared else self.n_mixtures * self.r
+            if "D" in const:
+                self.D_param = nn.Parameter(0.1 * torch.randn(orient_size))
+            else:
+                self.fc_D = WeightNormLinear(self.final_hidden_dim, orient_size)
+
+        if cfg.nu_mode == "F":
+            if fixed_nu is None:
+                raise ValueError("fixed_nu must be provided when using 'F' in the constraint")
+            if len(fixed_nu) != self.n_mixtures:
+                raise ValueError("fixed_nu must match the number of mixtures")
+            values = torch.tensor(
+                [float("nan") if v is None else float(v) for v in fixed_nu],
+                dtype=torch.float,
+            )
+            mask = ~torch.isnan(values)
+            self.register_buffer("fixed_nu_mask", mask)
+            values = torch.nan_to_num(values, nan=0.0)
+            self.register_buffer("fixed_nu_values", values)
+            indices = (~mask).nonzero(as_tuple=False).view(-1)
+            self.register_buffer("nu_opt_indices", indices.long())
+            if indices.numel() > 0:
+                if "n" in const:
+                    self.nu_param_partial = nn.Parameter(torch.zeros(indices.numel()))
+                else:
+                    self.fc_nu_partial = WeightNormLinear(self.final_hidden_dim, indices.numel())
+                    with torch.no_grad():
+                        self.fc_nu_partial.V.normal_(0, 0.02)
+                        self.fc_nu_partial.g.zero_()
+                        self.fc_nu_partial.bias.zero_()
+        elif cfg.nu_mode != "N":
+            nu_size = 1 if cfg.nu_mode == "E" else self.n_mixtures
+            if "n" in const:
+                self.nu_param = nn.Parameter(torch.zeros(nu_size))
+            else:
+                self.fc_nu = WeightNormLinear(self.final_hidden_dim, nu_size)
+                with torch.no_grad():
+                    self.fc_nu.V.normal_(0, 0.02)
+                    self.fc_nu.g.zero_()
+                    self.fc_nu.bias.zero_()
+
+        if cfg.skew_mode != "N":
+            alpha_size = d if cfg.skew_mode == "E" else self.n_mixtures * d
+            if "s" in const:
+                self.alpha_param = nn.Parameter(0.05 * torch.randn(alpha_size))
+            else:
+                self.fc_alpha = WeightNormLinear(self.final_hidden_dim, alpha_size)
+                with torch.no_grad():
+                    self.fc_alpha.V.normal_(0, 0.02)
+                    self.fc_alpha.g.zero_()
+                    self.fc_alpha.bias.normal_(0, 0.02)
+
+    # ------------------------------------------------------------------
+    # Forward pass
+    # ------------------------------------------------------------------
+    def forward(self, x: Tensor, image_input: Optional[Tensor] = None) -> dict[str, Tensor]:
+        if self.tabular_module is not None:
+            tabular_features = self.tabular_module(x)
+        else:
+            tabular_features = x
+        if self.image_module is not None and image_input is not None:
+            image_features = self.image_module(image_input)
+            features = torch.cat([tabular_features, image_features], dim=1)
+        else:
+            features = tabular_features
+
+        h = self.hidden(features)
+        B = x.size(0)
+        d = self.output_dim
+
+        if "x" in self.constant_attr:
+            pi_logits = self.pi.unsqueeze(0).expand(B, -1)
+        else:
+            pi_logits = self.fc_pi(h)
+        pi_raw = torch.softmax(pi_logits, dim=1)
+        max_weight = 1.0 - (self.n_mixtures - 1) * self.min_mix_weight
+        pi_clamped = pi_raw.clamp(min=self.min_mix_weight, max=max_weight)
+        pi = pi_clamped / pi_clamped.sum(dim=1, keepdim=True)
+
+        if "m" in self.constant_attr:
+            mu = self.mu.unsqueeze(0).expand(B, -1, -1)
+        else:
+            raw_mu = self.fc_mu(h)
+            mu = raw_mu.view(B, self.n_mixtures, d)
+
+        if "L" in self.constant_attr:
+            raw_L = self.L_param.clamp(-20, 20)
+            L_val = F.softplus(raw_L) + 1e-6
+            L_val = L_val.unsqueeze(0).expand(B, -1)
+        else:
+            raw_L = self.fc_L(h).clamp(-20, 20)
+            L_val = F.softplus(raw_L) + 1e-6
+        if self.cfg.volume_shared:
+            L_val = L_val.expand(-1, self.n_mixtures)
+        L_val = L_val.unsqueeze(-1).unsqueeze(-1)
+
+        if self.cfg.shape_identity:
+            A_diag = torch.ones(B, self.n_mixtures, d, device=x.device, dtype=mu.dtype)
+        elif hasattr(self, "A_param"):
+            rawA = self.A_param.clamp(-20, 20)
+            rawA = F.softplus(rawA) + 1e-6
+            if self.cfg.shape_shared:
+                tmp = rawA.view(1, 1, -1)
+                A_diag = tmp.expand(B, self.n_mixtures, -1)
+            else:
+                tmp = rawA.view(1, self.n_mixtures, -1)
+                A_diag = tmp.expand(B, -1, -1)
+        else:
+            rawA = self.fc_A(h).clamp(-20, 20)
+            rawA = F.softplus(rawA) + 1e-6
+            if self.cfg.shape_shared:
+                A_diag = rawA.unsqueeze(1).expand(-1, self.n_mixtures, -1)
+            else:
+                A_diag = rawA.view(B, self.n_mixtures, -1)
+        prodA = A_diag.prod(dim=-1, keepdim=True)
+        A_diag = A_diag / (prodA.pow(1 / d))
+        A_diag = A_diag.clamp(min=self.min_vol_shape, max=1e3)
+
+        if self.cfg.orientation_identity:
+            eye = torch.eye(d, device=x.device, dtype=mu.dtype)
+            D_tensor = eye.view(1, 1, d, d).expand(B, self.n_mixtures, -1, -1)
+        elif hasattr(self, "fc_D"):
+            rawD = self.fc_D(h)
+            if self.cfg.orientation_shared:
+                rawD = rawD.unsqueeze(1).expand(-1, self.n_mixtures, -1)
+            else:
+                rawD = rawD.view(B, self.n_mixtures, self.r)
+            mats = [build_orthogonal_matrix(rawD[:, j, :], d) for j in range(self.n_mixtures)]
+            D_tensor = torch.stack(mats, dim=1)
+        else:
+            if self.cfg.orientation_shared:
+                raw = self.D_param.view(1, -1).expand(self.n_mixtures, -1)
+            else:
+                raw = self.D_param.view(self.n_mixtures, -1)
+            mats = []
+            for j in range(self.n_mixtures):
+                base = build_orthogonal_matrix(raw[j].unsqueeze(0), d)
+                mats.append(base.expand(B, -1, -1))
+            D_tensor = torch.stack(mats, dim=1)
+
+        if self.cfg.nu_mode == "N":
+            nu = torch.full((B, self.n_mixtures), self.max_nu, device=x.device, dtype=mu.dtype)
+        elif self.cfg.nu_mode == "F":
+            fixed_values = self.fixed_nu_values.to(device=x.device, dtype=mu.dtype)
+            mask = self.fixed_nu_mask.to(device=x.device)
+            nu = torch.zeros(B, self.n_mixtures, device=x.device, dtype=mu.dtype)
+            if mask.any():
+                nu[:, mask] = fixed_values[mask]
+            indices = self.nu_opt_indices
+            if indices.numel() > 0:
+                if hasattr(self, "nu_param_partial"):
+                    raw = self.nu_param_partial
+                    nu_opt = self.min_nu + (self.max_nu - self.min_nu) * torch.sigmoid(raw)
+                    nu[:, indices] = nu_opt.unsqueeze(0)
+                else:
+                    raw = self.fc_nu_partial(h)
+                    nu_opt = self.min_nu + (self.max_nu - self.min_nu) * torch.sigmoid(raw)
+                    nu[:, indices] = nu_opt
+            if not mask.any():
+                nu = nu + 0  # ensure proper tensor
+        elif hasattr(self, "nu_param"):
+            raw = self.nu_param
+            tmp = self.min_nu + (self.max_nu - self.min_nu) * torch.sigmoid(raw)
+            if self.cfg.nu_mode == "E":
+                nu = tmp.view(1, 1).expand(B, self.n_mixtures)
+            else:
+                nu = tmp.view(1, -1).expand(B, -1)
+        elif hasattr(self, "fc_nu"):
+            raw = self.fc_nu(h)
+            tmp = self.min_nu + (self.max_nu - self.min_nu) * torch.sigmoid(raw)
+            if self.cfg.nu_mode == "E":
+                nu = tmp.expand(-1, self.n_mixtures)
+            else:
+                nu = tmp
+        else:
+            raise RuntimeError("nu parameters not configured")
+
+        if self.cfg.skew_mode == "N":
+            alpha = torch.zeros(B, self.n_mixtures, d, device=x.device, dtype=mu.dtype)
+        elif hasattr(self, "alpha_param"):
+            raw = self.alpha_param
+            if self.cfg.skew_mode == "E":
+                alpha = raw.view(1, 1, -1).expand(B, self.n_mixtures, -1)
+            else:
+                alpha = raw.view(1, self.n_mixtures, -1).expand(B, -1, -1)
+        else:
+            raw = self.fc_alpha(h)
+            if self.cfg.skew_mode == "E":
+                alpha = raw.unsqueeze(1).expand(-1, self.n_mixtures, -1)
+            else:
+                alpha = raw.view(B, self.n_mixtures, -1)
+        alpha = self.max_alpha * torch.tanh(alpha)
+
+        lambda_half = torch.sqrt(L_val)
+        sqrtA = torch.sqrt(A_diag)
+        sqrtA_mats = torch.diag_embed(sqrtA)
+        L_direct = torch.matmul(D_tensor, sqrtA_mats)
+        L_direct = lambda_half * L_direct
+        Sigma = torch.matmul(L_direct, L_direct.transpose(-2, -1))
+        eye = torch.eye(d, device=x.device, dtype=mu.dtype).view(1, 1, d, d)
+        scale_chol = torch.linalg.cholesky(Sigma + self.jitter * eye)
+
+        return {
+            "pi": pi,
+            "mu": mu,
+            "scale_chol": scale_chol,
+            "nu": nu,
+            "alpha": alpha,
+            "L": L_val,
+            "A": A_diag,
+            "D": D_tensor,
+        }

--- a/python/src/mst_pmdn/modules.py
+++ b/python/src/mst_pmdn/modules.py
@@ -1,0 +1,39 @@
+"""Model components for MST-PMDN."""
+
+from __future__ import annotations
+
+import torch
+from torch import nn
+
+
+class WeightNormLinear(nn.Module):
+    """Weight normalised linear layer mirroring the R implementation."""
+
+    def __init__(self, in_features: int, out_features: int, bias: bool = True) -> None:
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.V = nn.Parameter(torch.randn(out_features, in_features) / in_features**0.5)
+        self.g = nn.Parameter(torch.ones(out_features))
+        if bias:
+            self.bias = nn.Parameter(torch.zeros(out_features))
+        else:
+            self.register_parameter("bias", None)
+
+    def forward(self, input: torch.Tensor) -> torch.Tensor:  # type: ignore[override]
+        V_norm = self.V / (self.V.norm(dim=1, keepdim=True) + 1e-12)
+        W = self.g.unsqueeze(1) * V_norm
+        output = input @ W.T
+        if self.bias is not None:
+            output = output + self.bias
+        return output
+
+
+def init_weight_norm(module: nn.Module) -> None:
+    """Module initialiser used across the head."""
+
+    if isinstance(module, WeightNormLinear):
+        nn.init.kaiming_normal_(module.V, mode="fan_out")
+        with torch.no_grad():
+            norm = module.V.norm(dim=1)
+            module.g.copy_(norm)

--- a/python/src/mst_pmdn/sampling.py
+++ b/python/src/mst_pmdn/sampling.py
@@ -1,0 +1,47 @@
+"""Sampling utilities for MST-PMDN."""
+
+from __future__ import annotations
+
+import torch
+from torch import Tensor
+
+from .utils import sample_gamma
+
+
+def sample_mst_pmdn(output: dict[str, Tensor], num_samples: int = 1, device: str | torch.device | None = None) -> dict[str, Tensor]:
+    """Draw posterior samples from the skew-t mixture defined by ``output``."""
+
+    dev = device or output["pi"].device
+    dtype = output["pi"].dtype
+    pi = output["pi"].to(device=dev)
+    mu = output["mu"].to(device=dev)
+    L_all = output["scale_chol"].to(device=dev)
+    nu_all = output["nu"].to(device=dev)
+    alpha_all = output["alpha"].to(device=dev)
+
+    B, M, d = mu.shape
+    cat = torch.distributions.Categorical(pi)
+    idx = cat.sample((num_samples,)).transpose(0, 1)  # [B, S]
+    batch_indices = torch.arange(B, device=dev).unsqueeze(1).expand(-1, num_samples)
+
+    mu_s = mu[batch_indices, idx]
+    L_s = L_all[batch_indices, idx]
+    nu_s = nu_all[batch_indices, idx]
+    alpha_s = alpha_all[batch_indices, idx]
+
+    chi2 = sample_gamma(nu_s / 2, scale=2.0, device=dev, dtype=dtype)
+    W = torch.sqrt(nu_s / chi2.clamp(min=1e-12)).unsqueeze(-1)
+
+    alpha_norm_sq = alpha_s.pow(2).sum(dim=-1, keepdim=True)
+    delta = alpha_s / torch.sqrt(1 + alpha_norm_sq + 1e-10)
+    delta_norm_sq = delta.pow(2).sum(dim=-1, keepdim=True)
+
+    z0 = torch.randn(B, num_samples, 1, device=dev, dtype=dtype)
+    z1 = torch.randn(B, num_samples, d, device=dev, dtype=dtype)
+    X = delta * torch.abs(z0) + torch.sqrt((1 - delta_norm_sq).clamp(min=1e-12)) * z1
+
+    Y = mu_s + W * (torch.matmul(L_s, X.unsqueeze(-1)).squeeze(-1))
+    samples = Y.permute(1, 0, 2).contiguous()
+    components = idx.permute(1, 0).contiguous()
+
+    return {"samples": samples, "components": components}

--- a/python/src/mst_pmdn/train.py
+++ b/python/src/mst_pmdn/train.py
@@ -1,0 +1,141 @@
+"""Simple training helper for MST-PMDN models."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass
+from typing import List, Optional
+
+import torch
+from torch import Tensor, nn
+from torch.utils.data import DataLoader, TensorDataset
+
+from .losses import mst_pmdn_nll
+
+
+@dataclass
+class TrainingHistory:
+    train_loss: List[float]
+    val_loss: List[Optional[float]]
+
+
+def _make_dataset(inputs: Tensor, targets: Tensor, image_inputs: Optional[Tensor]) -> TensorDataset:
+    if image_inputs is None:
+        return TensorDataset(inputs, targets)
+    return TensorDataset(inputs, image_inputs, targets)
+
+
+def _split_dataset(dataset: TensorDataset, val_split: float) -> tuple[TensorDataset, Optional[TensorDataset]]:
+    if val_split <= 0:
+        return dataset, None
+    if not 0 < val_split < 1:
+        raise ValueError("val_split must be in (0, 1)")
+    length = len(dataset)
+    val_len = int(length * val_split)
+    perm = torch.randperm(length)
+    val_idx = perm[:val_len]
+    train_idx = perm[val_len:]
+    train_tensors = [tensor[train_idx] for tensor in dataset.tensors]
+    val_tensors = [tensor[val_idx] for tensor in dataset.tensors]
+    return TensorDataset(*train_tensors), TensorDataset(*val_tensors)
+
+
+def train_mst_pmdn(
+    model: nn.Module,
+    inputs: Tensor,
+    targets: Tensor,
+    *,
+    image_inputs: Optional[Tensor] = None,
+    epochs: int = 100,
+    batch_size: int = 64,
+    lr: float = 1e-3,
+    val_split: float = 0.0,
+    device: Optional[torch.device | str] = None,
+    lambda_alpha: float = 0.0,
+    lambda_nu_inv: float = 0.0,
+    patience: Optional[int] = None,
+) -> TrainingHistory:
+    """Train an ``MSTPMDN`` model using mini-batch gradient descent."""
+
+    dataset = _make_dataset(inputs, targets, image_inputs)
+    train_dataset, val_dataset = _split_dataset(dataset, val_split)
+
+    device = torch.device(device or inputs.device)
+    model.to(device)
+
+    def _loader(ds: TensorDataset, shuffle: bool) -> DataLoader:
+        return DataLoader(ds, batch_size=batch_size, shuffle=shuffle)
+
+    train_loader = _loader(train_dataset, shuffle=True)
+    val_loader = _loader(val_dataset, shuffle=False) if val_dataset is not None else None
+
+    optimizer = torch.optim.Adam(model.parameters(), lr=lr)
+    best_state = None
+    best_val = float("inf")
+    wait = 0
+    history = TrainingHistory(train_loss=[], val_loss=[])
+
+    for _ in range(epochs):
+        model.train()
+        total_loss = 0.0
+        count = 0
+        for batch in train_loader:
+            optimizer.zero_grad()
+            if image_inputs is None:
+                x, y = batch
+                x = x.to(device)
+                y = y.to(device)
+                output = model(x)
+            else:
+                x, im, y = batch
+                x = x.to(device)
+                im = im.to(device)
+                y = y.to(device)
+                output = model(x, image_input=im)
+            loss = mst_pmdn_nll(output, y, lambda_alpha=lambda_alpha, lambda_nu_inv=lambda_nu_inv)
+            loss.backward()
+            torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=5.0)
+            optimizer.step()
+            total_loss += loss.item()
+            count += 1
+        epoch_loss = total_loss / max(count, 1)
+        history.train_loss.append(epoch_loss)
+
+        if val_loader is not None:
+            model.eval()
+            with torch.no_grad():
+                val_total = 0.0
+                val_count = 0
+                for batch in val_loader:
+                    if image_inputs is None:
+                        x, y = batch
+                        x = x.to(device)
+                        y = y.to(device)
+                        output = model(x)
+                    else:
+                        x, im, y = batch
+                        x = x.to(device)
+                        im = im.to(device)
+                        y = y.to(device)
+                        output = model(x, image_input=im)
+                    loss = mst_pmdn_nll(output, y, lambda_alpha=lambda_alpha, lambda_nu_inv=lambda_nu_inv)
+                    val_total += loss.item()
+                    val_count += 1
+                val_loss = val_total / max(val_count, 1)
+            history.val_loss.append(val_loss)
+
+            if val_loss < best_val:
+                best_val = val_loss
+                best_state = deepcopy(model.state_dict())
+                wait = 0
+            else:
+                wait += 1
+                if patience is not None and wait >= patience:
+                    break
+        else:
+            history.val_loss.append(None)
+
+    if best_state is not None:
+        model.load_state_dict(best_state)
+
+    return history

--- a/python/src/mst_pmdn/utils.py
+++ b/python/src/mst_pmdn/utils.py
@@ -1,0 +1,148 @@
+"""Utility helpers for the PyTorch MST-PMDN implementation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+from torch import Tensor
+
+
+@dataclass(frozen=True)
+class ConstraintConfig:
+    """Parsed constraint string controlling covariance structure."""
+
+    volume_shared: bool
+    shape_shared: bool
+    shape_identity: bool
+    orientation_shared: bool
+    orientation_identity: bool
+    nu_mode: str
+    skew_mode: str
+
+
+def parse_constraint(constraint: str) -> ConstraintConfig:
+    """Parse the five letter constraint string used by the R implementation."""
+
+    if len(constraint) != 5:
+        raise ValueError("constraint must be a five character string")
+    vol, shape, orient, nu, skew = constraint.upper()
+    if vol not in {"E", "V"}:
+        raise ValueError("volume constraint must be 'E' or 'V'")
+    if shape not in {"E", "V", "I"}:
+        raise ValueError("shape constraint must be 'E', 'V' or 'I'")
+    if orient not in {"E", "V", "I"}:
+        raise ValueError("orientation constraint must be 'E', 'V' or 'I'")
+    if nu not in {"E", "V", "N", "F"}:
+        raise ValueError("nu constraint must be 'E', 'V', 'N' or 'F'")
+    if skew not in {"E", "V", "N"}:
+        raise ValueError("skew constraint must be 'E', 'V' or 'N'")
+    return ConstraintConfig(
+        volume_shared=(vol == "E"),
+        shape_shared=(shape == "E"),
+        shape_identity=(shape == "I"),
+        orientation_shared=(orient == "E"),
+        orientation_identity=(orient == "I"),
+        nu_mode=nu,
+        skew_mode=skew,
+    )
+
+
+def sample_gamma(shape: Tensor | float, scale: Tensor | float = 1.0, device: str | torch.device | None = None,
+                 dtype: torch.dtype | None = None) -> Tensor:
+    """Gamma samples drawn on-device.
+
+    Parameters mirror the R helper: ``shape`` is the concentration parameter, ``scale``
+    the standard deviation scaling (``rate = 1 / scale`` in PyTorch).
+    """
+
+    shape_tensor = torch.as_tensor(shape, device=device, dtype=dtype or torch.get_default_dtype())
+    scale_tensor = torch.as_tensor(scale, device=shape_tensor.device, dtype=shape_tensor.dtype)
+    if torch.any(shape_tensor <= 0):
+        raise ValueError("shape parameters must be positive")
+    if torch.any(scale_tensor <= 0):
+        raise ValueError("scale parameters must be positive")
+    rate = 1.0 / scale_tensor
+    gamma = torch.distributions.Gamma(concentration=shape_tensor, rate=rate)
+    return gamma.rsample()
+
+
+def build_orthogonal_matrix(params: Tensor, dim: int) -> Tensor:
+    """Construct an orthogonal matrix from skew-symmetric parameters.
+
+    The routine mirrors the R helper by first populating a skew-symmetric matrix using
+    the upper triangular portion of ``params`` (of size ``dim * (dim - 1) / 2``),
+    computing its matrix exponential and finally retrieving the orthogonal factor of
+    a QR decomposition.
+    """
+
+    if params.dim() == 1:
+        params = params.unsqueeze(0)
+    batch, param_dim = params.shape
+    expected = dim * (dim - 1) // 2
+    if param_dim != expected:
+        raise ValueError(f"Expected {expected} params for dim={dim}, received {param_dim}")
+    device = params.device
+    dtype = params.dtype
+    indices = torch.triu_indices(row=dim, col=dim, offset=1, device=device)
+    rows, cols = indices
+    X = torch.zeros(batch, dim, dim, device=device, dtype=dtype)
+    X[:, rows, cols] = params
+    X = X - X.transpose(1, 2)
+    Q = torch.matrix_exp(X)
+    # QR decomposition to guarantee orthogonality even with numerical drift
+    q, _ = torch.linalg.qr(Q)
+    return q
+
+
+def _kmeans_assign(data: Tensor, centroids: Tensor) -> Tensor:
+    """Assign each point to the closest centroid."""
+
+    distances = torch.cdist(data, centroids, p=2)
+    return distances.argmin(dim=1)
+
+
+def _update_centroids(data: Tensor, assignments: Tensor, k: int) -> Tensor:
+    new_centroids = []
+    for idx in range(k):
+        mask = assignments == idx
+        if not torch.any(mask):
+            # Re-sample a random point when a cluster becomes empty
+            rand_idx = torch.randint(0, data.shape[0], (1,), device=data.device)
+            new_centroids.append(data[rand_idx])
+        else:
+            new_centroids.append(data[mask].mean(dim=0, keepdim=True))
+    return torch.cat(new_centroids, dim=0)
+
+
+def simple_kmeans(data: Tensor, k: int, iters: int = 15) -> Tensor:
+    """Small utility K-means implementation used for mu initialisation."""
+
+    if data.dim() != 2:
+        raise ValueError("k-means expects a 2D tensor")
+    if data.shape[0] < k:
+        raise ValueError("number of samples must be >= k")
+    # Choose random distinct starting points
+    perm = torch.randperm(data.shape[0], device=data.device)
+    centroids = data[perm[:k]].clone()
+    for _ in range(iters):
+        assignments = _kmeans_assign(data, centroids)
+        centroids = _update_centroids(data, assignments, k)
+    return centroids
+
+
+def init_mu_kmeans(model: torch.nn.Module, outputs_train: Tensor, n_mixtures: int,
+                   constant_attr: str, device: torch.device | str | None = None) -> None:
+    """Initialise component means in place using K-means centroids."""
+
+    data = outputs_train.to(device or outputs_train.device)
+    centroids = simple_kmeans(data, n_mixtures)
+    if "m" in constant_attr:
+        with torch.no_grad():
+            model.mu.copy_(centroids)
+    else:
+        with torch.no_grad():
+            bias = model.fc_mu.bias.view(n_mixtures, -1)
+            bias.copy_(centroids)
+            model.fc_mu.g.zero_()
+

--- a/python/tests/test_distributions.py
+++ b/python/tests/test_distributions.py
@@ -1,0 +1,22 @@
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from mst_pmdn.distributions import log_student_t_cdf, student_t_cdf
+
+
+def test_student_t_cdf_matches_torch_distribution():
+    z = torch.linspace(-3, 3, 7)
+    nu = torch.tensor([3.0])
+    expected = torch.distributions.StudentT(df=nu).cdf(z)
+    actual = student_t_cdf(z, nu)
+    assert torch.allclose(actual, expected, atol=1e-6)
+
+
+def test_log_student_t_cdf_has_grad():
+    z = torch.tensor([0.1, 0.5, -0.2], requires_grad=True)
+    nu = torch.tensor([4.0])
+    loss = log_student_t_cdf(z, nu).sum()
+    loss.backward()
+    assert z.grad is not None
+    assert torch.all(torch.isfinite(z.grad))

--- a/python/tests/test_model.py
+++ b/python/tests/test_model.py
@@ -1,0 +1,60 @@
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from mst_pmdn.model import MSTPMDN
+
+
+def make_model(**kwargs):
+    return MSTPMDN(
+        input_dim=4,
+        output_dim=2,
+        hidden_dim=(8, 8),
+        n_mixtures=3,
+        **kwargs,
+    )
+
+
+def test_forward_shapes_and_constraints():
+    model = make_model()
+    x = torch.randn(5, 4)
+    out = model(x)
+    assert out["pi"].shape == (5, 3)
+    assert torch.allclose(out["pi"].sum(dim=1), torch.ones(5))
+    assert out["mu"].shape == (5, 3, 2)
+    assert out["scale_chol"].shape == (5, 3, 2, 2)
+    assert out["alpha"].shape == (5, 3, 2)
+    diag = out["scale_chol"].diagonal(dim1=-2, dim2=-1)
+    assert torch.all(diag > 0)
+
+
+def test_degrees_of_freedom_clamped_to_range():
+    model = make_model(constraint="VVVVE")
+    x = torch.randn(2, 4)
+    out = model(x)
+    nu = out["nu"]
+    assert torch.all((nu >= model.min_nu - 1e-5) & (nu <= model.max_nu + 1e-5))
+
+
+def test_no_skew_returns_zero_alpha():
+    model = make_model(constraint="VVVVN")
+    x = torch.randn(3, 4)
+    out = model(x)
+    assert torch.allclose(out["alpha"], torch.zeros_like(out["alpha"]))
+
+
+def test_shared_orientation_is_orthogonal():
+    model = make_model(constraint="EEEVV")
+    x = torch.randn(2, 4)
+    out = model(x)
+    D = out["D"]  # [B, M, d, d]
+    mat = D[0, 0]
+    should_be_identity = mat @ mat.t()
+    assert torch.allclose(should_be_identity, torch.eye(2), atol=1e-5)
+
+
+def test_constant_mixture_weights_shared_across_batch():
+    model = make_model(constraint="VVVNN", constant_attr="x")
+    x = torch.randn(6, 4)
+    out = model(x)
+    assert torch.allclose(out["pi"], out["pi"][0].unsqueeze(0).expand_as(out["pi"]))

--- a/python/tests/test_sampling.py
+++ b/python/tests/test_sampling.py
@@ -1,0 +1,18 @@
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from mst_pmdn.model import MSTPMDN
+from mst_pmdn.sampling import sample_mst_pmdn
+
+
+def test_sampling_shapes_and_component_range():
+    torch.manual_seed(1)
+    model = MSTPMDN(input_dim=3, output_dim=2, hidden_dim=6, n_mixtures=4)
+    x = torch.randn(5, 3)
+    out = model(x)
+    samples = sample_mst_pmdn(out, num_samples=10)
+    assert samples["samples"].shape == (10, 5, 2)
+    assert samples["components"].shape == (10, 5)
+    assert samples["components"].max() < 4
+    assert samples["components"].min() >= 0

--- a/python/tests/test_train.py
+++ b/python/tests/test_train.py
@@ -1,0 +1,27 @@
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from mst_pmdn.losses import mst_pmdn_nll
+from mst_pmdn.model import MSTPMDN
+from mst_pmdn.train import train_mst_pmdn
+
+
+def test_training_loop_reduces_loss():
+    torch.manual_seed(42)
+    inputs = torch.randn(200, 3)
+    weights = torch.tensor([[1.0, -0.5, 0.25], [-0.75, 0.6, 0.4]])
+    noise = 0.1 * torch.randn(200, 2)
+    outputs = inputs @ weights.t() + noise
+
+    model = MSTPMDN(input_dim=3, output_dim=2, hidden_dim=(16,), n_mixtures=2, constraint="VVVVE")
+    with torch.no_grad():
+        initial_loss = mst_pmdn_nll(model(inputs), outputs).item()
+
+    history = train_mst_pmdn(model, inputs, outputs, epochs=20, batch_size=32, lr=5e-3, val_split=0.2, patience=5)
+
+    with torch.no_grad():
+        final_loss = mst_pmdn_nll(model(inputs), outputs).item()
+
+    assert history.train_loss
+    assert final_loss < initial_loss

--- a/python/tests/test_utils.py
+++ b/python/tests/test_utils.py
@@ -1,0 +1,33 @@
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from mst_pmdn.utils import build_orthogonal_matrix, sample_gamma, simple_kmeans
+
+
+def test_sample_gamma_matches_mean():
+    shape = torch.tensor([2.0, 3.0])
+    scale = torch.tensor([1.5, 0.7])
+    samples = sample_gamma(shape.unsqueeze(0).expand(10000, -1), scale)
+    empirical_mean = samples.mean(dim=0)
+    expected = shape * scale
+    assert torch.allclose(empirical_mean, expected, atol=0.05, rtol=0.05)
+
+
+def test_build_orthogonal_matrix_returns_orthonormal_rows():
+    params = torch.randn(4, 3)
+    mat = build_orthogonal_matrix(params, dim=3)
+    should_be_identity = mat @ mat.transpose(1, 2)
+    eye = torch.eye(3)
+    assert torch.allclose(should_be_identity, eye, atol=1e-5, rtol=1e-5)
+
+
+def test_simple_kmeans_finds_centroids():
+    torch.manual_seed(0)
+    centers = torch.tensor([[0.0, 0.0], [5.0, 5.0]])
+    points = torch.cat([centers[0].unsqueeze(0) + 0.1 * torch.randn(100, 2),
+                        centers[1].unsqueeze(0) + 0.1 * torch.randn(100, 2)])
+    centroids = simple_kmeans(points, k=2, iters=20)
+    dists = torch.cdist(centroids, centers)
+    assignment = dists.argmin(dim=1)
+    assert torch.all(dists[torch.arange(2), assignment] < 0.3)


### PR DESCRIPTION
## Summary
- add a standalone `mst_pmdn` Python package that mirrors the R MST-PMDN head, including weight-normalised layers, constrained parameter handling, and differentiable Student-t utilities
- provide training, sampling, and loss helpers along with documentation covering the package layout and usage
- include a pytest-based test-suite that exercises the utilities, distribution helpers, model outputs, sampling path, and training loop

## Testing
- PYTHONPATH=src pytest *(skipped: torch not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cdb545b284832582dbfbfa19ab28c9