### PR TITLE
Fix triu index offset in build_orthogonal_matrix and bump torch dependency to 0.17.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,7 @@ Author: Alex J. Cannon [aut, cre] (<https://orcid.org/0000-0002-8025-3790>)
 Description: Implements the Multivariate Skew t-Parsimonious Mixture Density Network (MST-PMDN), a distributional deep learning regression framework based on a mixture of MST distributions. Provides user‐facing functions to define, train, predict, and sample from deep MST-PMDN models built with torch for R.
 License: GPL (>= 2)
 Encoding: UTF-8
-Depends: R (>= 3.5.0), torch (>= 0.13.0)
+Depends: R (>= 3.5.0), torch (>= 0.17.0)
 Imports: coro, stats
 LazyData: true
 LazyDataCompression: xz

--- a/R/MST-PMDN.R
+++ b/R/MST-PMDN.R
@@ -42,8 +42,8 @@ build_orthogonal_matrix <- function(params, dim) {
   X <- torch_zeros(batch_size, dim, dim, device = dev)
   indices_orig <- torch_triu_indices(dim, dim, offset = 1,
                                      dtype = torch_long(), device = dev)
-  row_indices_1d <- indices_orig[1, ]$add(1)$to(dtype = torch_long())
-  col_indices_1d <- indices_orig[2, ]$add(1)$to(dtype = torch_long())
+  row_indices_1d <- indices_orig[1, ]$to(dtype = torch_long())
+  col_indices_1d <- indices_orig[2, ]$to(dtype = torch_long())
   batch_vals <- torch_arange(1, batch_size, device = dev, dtype = torch_long())
   # Expand batch, row, and column indices for broadcasting
   num_triu_elements <- indices_orig$size(2)


### PR DESCRIPTION
### Motivation

- Fix an incorrect index offset when constructing the orthogonal matrix from upper-triangular parameters to restore correct indexing under newer `torch` behavior and ensure compatibility by requiring `torch (>= 0.17.0)`.

### Description

- Remove the erroneous `add(1)` adjustments for `row_indices_1d` and `col_indices_1d` in `build_orthogonal_matrix` so indices from `torch_triu_indices` are used directly, and update `DESCRIPTION` to require `torch (>= 0.17.0)`.

### Testing

- Ran `R CMD check` and the package unit tests that exercise `build_orthogonal_matrix` and initialization paths, and they completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd4262d12c83259ba0f347fc877353)