### PR TITLE
Fix sampling, covariance, and training state handling

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,0 +1,25 @@
+name: R-CMD-check
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  R-CMD-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::rcmdcheck
+          needs: check
+      - name: Install libtorch
+        run: Rscript -e 'torch::install_torch()'
+      - uses: r-lib/actions/check-r-package@v2

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: MST.PMDN
 Type: Package
 Title: Deep Multivariate Skew t-Parsimonious Mixture Density Network
-Version: 0.1.3
+Version: 0.2.0
 Authors@R: person(given="Alex J.", family="Cannon",
     email="alex.cannon@ec.gc.ca", role=c("aut", "cre"),
     comment=c(ORCID="0000-0002-8025-3790"))
@@ -12,6 +12,8 @@ License: GPL (>= 2)
 Encoding: UTF-8
 Depends: R (>= 3.5.0), torch (>= 0.17.0)
 Imports: coro, stats
+Suggests: testthat (>= 3.0.0)
+Config/testthat/edition: 3
 LazyData: true
 LazyDataCompression: xz
 NeedsCompilation: no

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,14 @@
+# MST.PMDN 0.2.0
+
+- Corrected one-based mixture-component sampling and the multivariate
+  skew-normal construction used by both sampling helpers.
+- Corrected the empirical marginal CDF estimator.
+- Distinguished skew-t scale matrices from component covariance matrices and
+  documented `mu` as a location parameter.
+- Preserved the intended neutral initialization of learned `nu` and `alpha`
+  heads.
+- Made checkpoints fully resumable by restoring optimizer, split, history,
+  counters, and available R/torch RNG state; latest and best states now use
+  separate files.
+- Validation now evaluates every case and reports observation-weighted losses.
+- Added regression tests and an R CMD check workflow.

--- a/R/MST-PMDN.R
+++ b/R/MST-PMDN.R
@@ -35,6 +35,15 @@ sample_gamma <- function(shape, scale = 1, device = "cpu") {
   return(out)
 }
 
+validate_num_samples <- function(num_samples) {
+  if (!is.numeric(num_samples) || length(num_samples) != 1 ||
+      !is.finite(num_samples) || num_samples < 1 ||
+      num_samples != floor(num_samples)) {
+    stop("num_samples must be a positive integer.")
+  }
+  as.integer(num_samples)
+}
+
 build_orthogonal_matrix <- function(params, dim) {
   # Helper for building an orthogonal orientation matrix
   dev <- params$device
@@ -169,6 +178,62 @@ init_weight_norm <- function(module) {
       module$g$copy_(norm_v)
     })
   }
+}
+
+init_distribution_heads <- function(model) {
+  # Apply specialized initialization after the generic weight-normalized
+  # initialization so learned nu and alpha begin input-independent.
+  with_no_grad({
+    for (head_name in c("fc_nu", "fc_nu_partial")) {
+      head <- model[[head_name]]
+      if (!is.null(head)) {
+        head$V$normal_(0, 0.02)
+        head$g$zero_()
+        head$bias$zero_()
+      }
+    }
+    if (!is.null(model$fc_alpha)) {
+      model$fc_alpha$V$normal_(0, 0.02)
+      model$fc_alpha$g$zero_()
+      model$fc_alpha$bias$zero_()
+    }
+  })
+}
+
+derive_checkpoint_path <- function(path, suffix) {
+  derived <- sub("\\.pt$", paste0(suffix, ".pt"), path)
+  if (identical(derived, path)) {
+    derived <- paste0(path, suffix)
+  }
+  derived
+}
+
+capture_training_rng_state <- function() {
+  list(
+    r = if (exists(".Random.seed", envir = .GlobalEnv, inherits = FALSE)) {
+      get(".Random.seed", envir = .GlobalEnv, inherits = FALSE)
+    } else {
+      NULL
+    },
+    torch = torch_get_rng_state(),
+    cuda = if (cuda_is_available()) cuda_get_rng_state() else NULL
+  )
+}
+
+restore_training_rng_state <- function(state) {
+  if (is.null(state)) {
+    return(invisible(FALSE))
+  }
+  if (!is.null(state$r)) {
+    assign(".Random.seed", state$r, envir = .GlobalEnv)
+  }
+  if (!is.null(state$torch)) {
+    torch_set_rng_state(state$torch)
+  }
+  if (!is.null(state$cuda) && cuda_is_available()) {
+    cuda_set_rng_state(state$cuda)
+  }
+  invisible(TRUE)
 }
 
 # -----------------------------------------
@@ -314,7 +379,7 @@ define_mst_pmdn <- function(
         self$fc_pi <- weight_norm_linear(self$final_hidden_dim, n_mixtures)
       }
       # ----------
-      # Means (mu)
+      # Locations (mu)
       # ----------
       if (grepl("m", constant_attr)) {
         self$mu <- nn_parameter(torch_randn(n_mixtures, output_dim))
@@ -454,7 +519,7 @@ define_mst_pmdn <- function(
           self$fc_alpha <- weight_norm_linear(self$final_hidden_dim, alpha_size)      
           with_no_grad({
             self$fc_alpha$V$normal_(0, 0.02)
-            self$fc_alpha$bias$normal_(0, 0.02)
+            self$fc_alpha$bias$zero_()
             self$fc_alpha$g$fill_(0)
           })
         }
@@ -510,7 +575,7 @@ define_mst_pmdn <- function(
       pi_clamped <- pi_raw$clamp(min = self$min_mix_weight, max = max_weight)
       pi <- pi_clamped / pi_clamped$sum(dim = 2, keepdim = TRUE)
       # ----------
-      # Means (mu)
+      # Locations (mu)
       # ----------
       if (grepl("m", self$constant_attr)) {
         mu <- self$mu$unsqueeze(1)$expand(c(B, -1, -1)) # [B, M, d]
@@ -797,6 +862,7 @@ loss_mst_pmdn <- function(output, target,
 # -----------------------------------------------
 
 sample_mst_pmdn <- function(mdn_output, num_samples = 1, device = "cpu") {
+  num_samples <- validate_num_samples(num_samples)
   # gather parameters
   pi     <- mdn_output$pi          $to(device = device)
   mu     <- mdn_output$mu          $to(device = device)
@@ -806,8 +872,9 @@ sample_mst_pmdn <- function(mdn_output, num_samples = 1, device = "cpu") {
   B <- pi$size(1)
   # M <- pi$size(2)
   d <- mu$size(3)
-  # component indices (1-based)
-  idx      <- pi$multinomial(num_samples, replacement = TRUE)$add(1L)
+  # Use the public torch wrapper, which converts libtorch's zero-based result
+  # to the one-based indices expected by R torch indexing operations.
+  idx      <- torch_multinomial(pi, num_samples, replacement = TRUE)
   idx_d    <- idx$unsqueeze(-1)$expand(c(B, num_samples, d))
   idx_dd   <- idx$unsqueeze(-1)$unsqueeze(-1)$expand(c(B, num_samples, d, d))
   # gather parameters for the selected components
@@ -820,14 +887,23 @@ sample_mst_pmdn <- function(mdn_output, num_samples = 1, device = "cpu") {
   W    <- torch_sqrt(nu_s / chi2$clamp(min = 1e-12))$unsqueeze(-1)
   # skew direction (identity-covariance, Sigma = I convention)
   alpha_norm_sq <- alpha_s$pow(2)$sum(dim = -1, keepdim = TRUE)
-  delta <- alpha_s / torch_sqrt(1 + alpha_norm_sq + 1e-10)
+  delta <- alpha_s / torch_sqrt(1 + alpha_norm_sq)
   delta_norm_sq <- delta$pow(2)$sum(dim = -1, keepdim = TRUE)
   # standard normals
   z0 <- torch_randn(c(B, num_samples, 1), device = device)
   z1 <- torch_randn(c(B, num_samples, d), device = device)
-  # skew-normal core
-  X <- delta * torch_abs(z0) +
-    torch_sqrt((1 - delta_norm_sq)$clamp(min = 1e-12)) * z1
+  # Skew-normal core.  The residual requires the symmetric matrix square root
+  # of I - delta delta^T.  Apply its rank-one form without materializing a
+  # [B, S, d, d] tensor:
+  # (I - delta delta^T)^(1/2) z =
+  # z - delta (delta^T z) / (1 + sqrt(1 - ||delta||^2)).
+  sqrt_one_minus_delta_sq <- torch_sqrt(
+    (1 - delta_norm_sq)$clamp(min = 1e-12)
+  )
+  delta_dot_z1 <- (delta * z1)$sum(dim = -1, keepdim = TRUE)
+  residual <- z1 - delta * delta_dot_z1 /
+    (1 + sqrt_one_minus_delta_sq)
+  X <- delta * torch_abs(z0) + residual
   # affine map to response space  Y
   Y <- mu_s + W * (torch_matmul(L_s, X$unsqueeze(-1))$squeeze(-1))
   # return both samples and component IDs
@@ -838,39 +914,17 @@ sample_mst_pmdn <- function(mdn_output, num_samples = 1, device = "cpu") {
 }
 
 sample_mst_pmdn_df <- function(mdn_output, num_samples = 1, device = "cpu") {
-  # gather parameters
-  pi         <- mdn_output$pi         $to(device = device)
-  mu         <- mdn_output$mu         $to(device = device)
-  L_all      <- mdn_output$scale_chol $to(device = device)
-  nu_all     <- mdn_output$nu         $to(device = device)
-  alpha_all  <- mdn_output$alpha      $to(device = device)
-  B <- pi$size(1)
-  # M <- pi$size(2)
-  d <- mu$size(3)
-  # component indices (1-based)
-  idx    <- pi$multinomial(num_samples, replacement = TRUE)$add(1L)
-  idx_d  <- idx$unsqueeze(-1)$expand(c(B, num_samples, d))
-  idx_dd <- idx$unsqueeze(-1)$unsqueeze(-1)$expand(c(B, num_samples, d, d))
-  # gather parameters for the selected components
-  mu_s     <- mu        $gather(2, idx_d)
-  L_s      <- L_all     $gather(2, idx_dd)
-  nu_s     <- nu_all    $gather(2, idx)
-  alpha_s  <- alpha_all $gather(2, idx_d)
-  # Gamma scaling for Student-t tails
-  chi2 <- sample_gamma(nu_s / 2, scale = 2, device = device)
-  W    <- torch_sqrt(nu_s / chi2$clamp(min = 1e-12))$unsqueeze(-1)
-  # skew direction (identity-covariance, Sigma = I convention)
-  alpha_norm_sq <- alpha_s$pow(2)$sum(dim = -1, keepdim = TRUE)
-  delta         <- alpha_s / torch_sqrt(1 + alpha_norm_sq)
-  delta_norm_sq <- delta$pow(2)$sum(dim = -1, keepdim = TRUE)
-  # standard normals
-  z0 <- torch_randn(c(B, num_samples, 1), device = device)
-  z1 <- torch_randn(c(B, num_samples, d), device = device)
-  # skew-normal core
-  X <- delta * torch_abs(z0) +
-    torch_sqrt((1 - delta_norm_sq)$clamp(min = 1e-12)) * z1
-  # affine map to response space  Y
-  Y <- mu_s + W * (torch_matmul(L_s, X$unsqueeze(-1))$squeeze(-1))
+  num_samples <- validate_num_samples(num_samples)
+  sampled <- sample_mst_pmdn(
+    mdn_output,
+    num_samples = num_samples,
+    device = device
+  )
+  # Restore [B, S, ...] layout for data-frame construction.
+  Y <- sampled$samples$permute(c(2, 1, 3))
+  idx <- sampled$components$permute(c(2, 1))
+  B <- Y$size(1)
+  d <- Y$size(3)
   # reshape to long data-frame
   S   <- num_samples
   mat  <- as.matrix(Y$reshape(c(B * S, d))$cpu())
@@ -899,9 +953,7 @@ cdf_marginal_mst_pmdn <- function(mdn_output,
   if (!all(required_fields %in% names(mdn_output))) {
     stop("mdn_output is missing required fields from predict_mst_pmdn.")
   }
-  if (!is.numeric(num_samples) || length(num_samples) != 1 || num_samples < 1) {
-    stop("num_samples must be a positive integer.")
-  }
+  num_samples <- validate_num_samples(num_samples)
   d <- mdn_output$mu$size(3)
   var_index_provided <- !is.null(var_index)
   if (!var_index_provided) {
@@ -982,11 +1034,7 @@ cdf_marginal_mst_pmdn <- function(mdn_output,
   x_broadcast <- x_tensor$unsqueeze(1)
   counts <- (samples <= x_broadcast)$to(dtype = torch_float())$sum(dim = 1)
   n_draws <- samples$size(1)
-  if (n_draws == 1) {
-    cdf <- counts
-  } else {
-    cdf <- ((counts - 1) / (n_draws - 1))$clamp(min = 0, max = 1)
-  }
+  cdf <- (counts / n_draws)$clamp(min = 0, max = 1)
   cdf
 }
 
@@ -1138,12 +1186,34 @@ train_mst_pmdn <- function(inputs,
                            min_last_batch_frac = 0.5,
                            device = "cpu"
 ) {
-  if (!is.numeric(batch_size) || length(batch_size) != 1 || !is.finite(batch_size) || batch_size < 1)
-    stop("batch_size must be a single positive number")
+  is_positive_integer <- function(x) {
+    is.numeric(x) && length(x) == 1 && is.finite(x) &&
+      x >= 1 && x == floor(x)
+  }
+  if (!is_positive_integer(batch_size))
+    stop("batch_size must be a single positive integer")
+  if (!is_positive_integer(epochs))
+    stop("epochs must be a single positive integer")
+  if (!is_positive_integer(checkpoint_interval))
+    stop("checkpoint_interval must be a single positive integer")
+  if (!is.null(scheduler_step) && !is_positive_integer(scheduler_step))
+    stop("scheduler_step must be NULL or a single positive integer")
   batch_size <- as.integer(batch_size)
+  epochs <- as.integer(epochs)
+  checkpoint_interval <- as.integer(checkpoint_interval)
+  if (!is.null(scheduler_step)) scheduler_step <- as.integer(scheduler_step)
   if (!is.numeric(min_last_batch_frac) || length(min_last_batch_frac) != 1 ||
-      !is.finite(min_last_batch_frac) || min_last_batch_frac < 0 || min_last_batch_frac > 1)
+      !is.finite(min_last_batch_frac) || min_last_batch_frac < 0 ||
+      min_last_batch_frac > 1)
     stop("min_last_batch_frac must be a single number between 0 and 1")
+  if (!is.numeric(validation_split) || length(validation_split) != 1 ||
+      !is.finite(validation_split) || validation_split < 0 ||
+      validation_split >= 1)
+    stop("validation_split must be a single number in [0, 1)")
+  if (isTRUE(resume_from_checkpoint) && !is.null(model))
+    stop("model and resume_from_checkpoint cannot be used together")
+  if (isTRUE(resume_from_checkpoint) && !file.exists(checkpoint_path))
+    stop("resume_from_checkpoint is TRUE but checkpoint_path does not exist")
 
   # Data preparation
   if (!inherits(inputs, "torch_tensor"))
@@ -1156,65 +1226,128 @@ train_mst_pmdn <- function(inputs,
     outputs <- outputs$to(device = device)
   if (!is.null(image_inputs)) {
     if (!inherits(image_inputs, "torch_tensor"))
-      image_inputs <- torch_tensor(image_inputs, device = device, dtype = torch_float())
+      image_inputs <- torch_tensor(image_inputs, device = device,
+                                   dtype = torch_float())
     else
       image_inputs <- image_inputs$to(device = device)
   }
-  # Data training/validation split
   n_total <- inputs$size(1)
-  if (!is.null(custom_split)) {
-    if (is.list(custom_split) && all(c("train", "validation") %in% names(custom_split))) {
-      train_indices <- custom_split$train
-      val_indices <- custom_split$validation
-    } else if (is.list(custom_split) && length(custom_split) == 2) {
-      train_indices <- custom_split[[1]]
-      val_indices <- custom_split[[2]]
-    } else if (is.numeric(custom_split)) {
-      val_indices <- custom_split
-      train_indices <- setdiff(seq_len(n_total), val_indices)
-    } else if (is.logical(custom_split) && length(custom_split) == n_total) {
-      train_indices <- which(custom_split)
-      val_indices <- which(!custom_split)
-    } else stop("Invalid custom_split format.")
-    if (length(train_indices) == 0 || length(val_indices) == 0)
-      stop("Both training and validation sets must contain at least one sample")
-  } else if (validation_split > 0 && validation_split < 1) {
-    val_indices <- sample.int(n_total, size = floor(n_total * validation_split))
-    train_indices <- setdiff(seq_len(n_total), val_indices)
-  } else {
-    train_indices <- seq_len(n_total)
-    val_indices <- integer(0)
+  input_dim <- inputs$size(2)
+  output_dim <- outputs$size(2)
+  if (outputs$size(1) != n_total)
+    stop("inputs and outputs must have the same number of rows")
+  if (!is.null(image_inputs) && image_inputs$size(1) != n_total)
+    stop("image_inputs must have the same number of rows as inputs")
+
+  resuming <- isTRUE(resume_from_checkpoint)
+  checkpoint <- if (resuming) torch_load(checkpoint_path) else NULL
+  if (resuming && !is.null(checkpoint$data_signature)) {
+    signature <- checkpoint$data_signature
+    if (!identical(as.integer(signature$n_total), as.integer(n_total)) ||
+        !identical(as.integer(signature$input_dim), as.integer(input_dim)) ||
+        !identical(as.integer(signature$output_dim), as.integer(output_dim)) ||
+        !identical(as.integer(signature$n_mixtures), as.integer(n_mixtures)) ||
+        !identical(signature$constraint, constraint) ||
+        !identical(signature$constant_attr, constant_attr)) {
+      stop("Checkpoint architecture or data dimensions do not match this run")
+    }
   }
+
+  # Restore the original split before making data subsets. Older checkpoints
+  # lack these fields and retain the legacy split behavior with a warning.
+  if (resuming && !is.null(checkpoint$train_indices) &&
+      !is.null(checkpoint$val_indices)) {
+    train_indices <- checkpoint$train_indices
+    val_indices <- checkpoint$val_indices
+    if (!is.null(custom_split)) {
+      warning("custom_split is ignored when resuming; using the split saved in the checkpoint.")
+    }
+  } else {
+    if (resuming) {
+      warning("Legacy checkpoint has no saved split; exact resumption is not possible.")
+    }
+    if (!is.null(custom_split)) {
+      if (is.list(custom_split) &&
+          all(c("train", "validation") %in% names(custom_split))) {
+        train_indices <- custom_split$train
+        val_indices <- custom_split$validation
+      } else if (is.list(custom_split) && length(custom_split) == 2) {
+        train_indices <- custom_split[[1]]
+        val_indices <- custom_split[[2]]
+      } else if (is.numeric(custom_split)) {
+        val_indices <- custom_split
+        train_indices <- setdiff(seq_len(n_total), val_indices)
+      } else if (is.logical(custom_split) && length(custom_split) == n_total) {
+        train_indices <- which(custom_split)
+        val_indices <- which(!custom_split)
+      } else {
+        stop("Invalid custom_split format.")
+      }
+    } else if (validation_split > 0) {
+      n_validation <- floor(n_total * validation_split)
+      if (n_validation < 1)
+        stop("validation_split produces an empty validation set")
+      val_indices <- sample.int(n_total, size = n_validation)
+      train_indices <- setdiff(seq_len(n_total), val_indices)
+    } else {
+      train_indices <- seq_len(n_total)
+      val_indices <- integer(0)
+    }
+  }
+  train_indices <- as.integer(train_indices)
+  val_indices <- as.integer(val_indices)
+  if (length(train_indices) == 0 || anyNA(train_indices) ||
+      any(train_indices < 1 | train_indices > n_total) ||
+      anyDuplicated(train_indices))
+    stop("Training indices must be unique, in bounds, and non-empty")
+  if (anyNA(val_indices) || any(val_indices < 1 | val_indices > n_total) ||
+      anyDuplicated(val_indices))
+    stop("Validation indices must be unique and in bounds")
+  if (length(intersect(train_indices, val_indices)) > 0)
+    stop("Training and validation indices must be disjoint")
+
   train_inputs <- inputs[train_indices, ]
   train_outputs <- outputs[train_indices, ]
-  train_image_inputs <- if (!is.null(image_inputs)) image_inputs[train_indices, ] else NULL
+  train_image_inputs <- if (!is.null(image_inputs)) {
+    image_inputs[train_indices, ]
+  } else {
+    NULL
+  }
   if (length(val_indices) > 0) {
     val_inputs <- inputs[val_indices, ]
     val_outputs <- outputs[val_indices, ]
-    val_image_inputs <- if (!is.null(image_inputs)) image_inputs[val_indices, ] else NULL
+    val_image_inputs <- if (!is.null(image_inputs)) {
+      image_inputs[val_indices, ]
+    } else {
+      NULL
+    }
   } else {
     val_inputs <- NULL
     val_outputs <- NULL
     val_image_inputs <- NULL
   }
+
+  extend_history <- function(history, length_out) {
+    if (is.null(history)) history <- numeric(0)
+    if (length(history) < length_out) {
+      history <- c(history, rep(NA_real_, length_out - length(history)))
+    }
+    history
+  }
+  history_length <- max(epochs, if (resuming) checkpoint$epoch else 0)
+
   # Model initialization logic
-  checkpoint <- NULL
   if (!is.null(model)) {
-    # Use provided model, reset all counters/optimizer
     model <- model$to(device = device)
-    start_epoch <- 1
-    train_loss_history <- rep(NA_real_, epochs)
-    val_loss_history   <- rep(NA_real_, epochs)
-    best_val_loss     <- Inf
-    best_val_epoch    <- NA
-    no_improve_epochs <- 0
-    best_train_loss   <- Inf
-    best_train_epoch  <- NA
-  } else if (resume_from_checkpoint && file.exists(checkpoint_path)) {
-    # Load from checkpoint, restore everything
-    checkpoint <- torch_load(checkpoint_path)
-    input_dim  <- inputs$size(2)
-    output_dim <- outputs$size(2)
+    start_epoch <- 1L
+    train_loss_history <- rep(NA_real_, history_length)
+    val_loss_history <- rep(NA_real_, history_length)
+    best_val_loss <- Inf
+    best_val_epoch <- NA_integer_
+    no_improve_epochs <- 0L
+    best_train_loss <- Inf
+    best_train_epoch <- NA_integer_
+  } else if (resuming) {
     model <- define_mst_pmdn(
       input_dim, output_dim, hidden_dim, n_mixtures,
       constraint, constant_attr,
@@ -1232,19 +1365,40 @@ train_mst_pmdn <- function(inputs,
     )
     model$load_state_dict(checkpoint$model_state_dict)
     model <- model$to(device = device)
-    train_loss_history <- checkpoint$train_loss_history
-    val_loss_history   <- checkpoint$val_loss_history
-    start_epoch        <- checkpoint$epoch + 1
-    best_val_loss      <- checkpoint$best_val_loss
-    best_val_epoch     <- checkpoint$best_val_epoch
-    no_improve_epochs  <- checkpoint$no_improve_epochs
-    best_train_loss    <- if (!is.null(checkpoint$best_train_loss)) checkpoint$best_train_loss else Inf
-    best_train_epoch   <- if (!is.null(checkpoint$best_train_epoch)) checkpoint$best_train_epoch else NA
-    cat(sprintf("Resumed from checkpoint at epoch %d with best_val_loss=%.4f\n", checkpoint$epoch, best_val_loss))
+    train_loss_history <- extend_history(
+      checkpoint$train_loss_history, history_length
+    )
+    val_loss_history <- extend_history(
+      checkpoint$val_loss_history, history_length
+    )
+    start_epoch <- as.integer(checkpoint$epoch) + 1L
+    best_val_loss <- if (!is.null(checkpoint$best_val_loss)) {
+      checkpoint$best_val_loss
+    } else {
+      Inf
+    }
+    best_val_epoch <- if (!is.null(checkpoint$best_val_epoch)) {
+      checkpoint$best_val_epoch
+    } else {
+      NA_integer_
+    }
+    no_improve_epochs <- if (!is.null(checkpoint$no_improve_epochs)) {
+      checkpoint$no_improve_epochs
+    } else {
+      0L
+    }
+    best_train_loss <- if (!is.null(checkpoint$best_train_loss)) {
+      checkpoint$best_train_loss
+    } else {
+      Inf
+    }
+    best_train_epoch <- if (!is.null(checkpoint$best_train_epoch)) {
+      checkpoint$best_train_epoch
+    } else {
+      NA_integer_
+    }
+    cat(sprintf("Resumed from checkpoint at epoch %d.\n", checkpoint$epoch))
   } else {
-    # New model, new optimizer, reset everything
-    input_dim  <- inputs$size(2)
-    output_dim <- outputs$size(2)
     model <- define_mst_pmdn(
       input_dim, output_dim, hidden_dim, n_mixtures,
       constraint, constant_attr,
@@ -1261,26 +1415,39 @@ train_mst_pmdn <- function(inputs,
       jitter = jitter
     )
     model$apply(init_weight_norm)
+    init_distribution_heads(model)
     model <- model$to(device = device)
-    init_mu_kmeans(model, outputs_train = train_outputs, n_mixtures = n_mixtures,
-                   constant_attr = constant_attr, device = device)
-    start_epoch <- 1
-    train_loss_history <- rep(NA_real_, epochs)
-    val_loss_history   <- rep(NA_real_, epochs)
-    best_val_loss     <- Inf
-    best_val_epoch    <- NA
-    no_improve_epochs <- 0
-    best_train_loss   <- Inf
-    best_train_epoch  <- NA
+    init_mu_kmeans(
+      model,
+      outputs_train = train_outputs,
+      n_mixtures = n_mixtures,
+      constant_attr = constant_attr,
+      device = device
+    )
+    start_epoch <- 1L
+    train_loss_history <- rep(NA_real_, history_length)
+    val_loss_history <- rep(NA_real_, history_length)
+    best_val_loss <- Inf
+    best_val_epoch <- NA_integer_
+    no_improve_epochs <- 0L
+    best_train_loss <- Inf
+    best_train_epoch <- NA_integer_
   }
+
   # Adam optimizer
-  img_params    <- if (!is.null(model$image_module))   model$image_module$parameters   else list()
-  tab_params    <- if (!is.null(model$tabular_module)) model$tabular_module$parameters else list()
-  fusion_params <- if (!is.null(model$fusion_module)) model$fusion_module$parameters else list()
+  img_params <- if (!is.null(model$image_module)) {
+    model$image_module$parameters
+  } else list()
+  tab_params <- if (!is.null(model$tabular_module)) {
+    model$tabular_module$parameters
+  } else list()
+  fusion_params <- if (!is.null(model$fusion_module)) {
+    model$fusion_module$parameters
+  } else list()
   hidden_params <- if (!is.null(model$hidden)) model$hidden$parameters else list()
-  all_params    <- model$parameters
-  feat_params   <- c(img_params, tab_params, fusion_params, hidden_params)
-  head_params   <- setdiff(all_params, feat_params)
+  all_params <- model$parameters
+  feat_params <- c(img_params, tab_params, fusion_params, hidden_params)
+  head_params <- setdiff(all_params, feat_params)
   optimizer <- optim_adam(
     params = list(
       list(params = img_params, weight_decay = wd_image),
@@ -1291,15 +1458,46 @@ train_mst_pmdn <- function(inputs,
     ),
     lr = lr
   )
-  # Restore optimizer state if resuming from checkpoint (but not for new
-  # phase/fine-tune)
-  if (!is.null(checkpoint) && is.null(model)) {
-    optimizer$load_state_dict(checkpoint$optimizer_state_dict)
+  if (resuming) {
+    if (is.null(checkpoint$optimizer_state_dict)) {
+      warning("Checkpoint has no optimizer state; optimizer starts fresh.")
+    } else {
+      optimizer$load_state_dict(checkpoint$optimizer_state_dict)
+    }
   }
 
-  best_train_checkpoint_path <- sub("\\.pt$", "_trainbest.pt", checkpoint_path)
-  if (identical(best_train_checkpoint_path, checkpoint_path))
-    best_train_checkpoint_path <- paste0(checkpoint_path, "_trainbest")
+  best_checkpoint_path <- derive_checkpoint_path(checkpoint_path, "_best")
+  best_train_checkpoint_path <- derive_checkpoint_path(
+    checkpoint_path, "_trainbest"
+  )
+
+  make_checkpoint <- function(epoch) {
+    list(
+      schema_version = 2L,
+      epoch = as.integer(epoch),
+      model_state_dict = model$state_dict(),
+      optimizer_state_dict = optimizer$state_dict(),
+      best_val_loss = best_val_loss,
+      best_val_epoch = best_val_epoch,
+      no_improve_epochs = no_improve_epochs,
+      best_train_loss = best_train_loss,
+      best_train_epoch = best_train_epoch,
+      train_loss_history = train_loss_history,
+      val_loss_history = val_loss_history,
+      train_indices = train_indices,
+      val_indices = val_indices,
+      data_signature = list(
+        n_total = n_total,
+        input_dim = input_dim,
+        output_dim = output_dim,
+        n_mixtures = n_mixtures,
+        constraint = constraint,
+        constant_attr = constant_attr
+      ),
+      rng_state = capture_training_rng_state()
+    )
+  }
+
   # Dataloaders
   dataset_fn <- function(inp, img_inp, outp) {
     if (is.null(img_inp)) {
@@ -1310,8 +1508,12 @@ train_mst_pmdn <- function(inputs,
       )(inp, outp)
     } else {
       dataset(
-        initialize = function(x, im, y) { self$x <- x; self$im <- im; self$y <- y },
-        .getitem = function(idx) list(self$x[idx, ], self$im[idx, ], self$y[idx, ]),
+        initialize = function(x, im, y) {
+          self$x <- x; self$im <- im; self$y <- y
+        },
+        .getitem = function(idx) {
+          list(self$x[idx, ], self$im[idx, ], self$y[idx, ])
+        },
         .length = function() self$x$size(1)
       )(inp, img_inp, outp)
     }
@@ -1319,178 +1521,203 @@ train_mst_pmdn <- function(inputs,
   should_drop_last_batch <- function(n_samples, batch_size, min_frac) {
     remainder <- n_samples %% batch_size
     min_last_batch_size <- ceiling(batch_size * min_frac)
-    n_samples > batch_size && remainder > 0 && remainder < min_last_batch_size
+    n_samples > batch_size && remainder > 0 &&
+      remainder < min_last_batch_size
   }
-
   train_dataset <- dataset_fn(train_inputs, train_image_inputs, train_outputs)
-  drop_last_train <- should_drop_last_batch(length(train_indices), batch_size, min_last_batch_frac)
-  train_loader  <- dataloader(train_dataset, batch_size = batch_size, shuffle = TRUE, drop_last = drop_last_train)
+  drop_last_train <- should_drop_last_batch(
+    length(train_indices), batch_size, min_last_batch_frac
+  )
+  train_loader <- dataloader(
+    train_dataset,
+    batch_size = batch_size,
+    shuffle = TRUE,
+    drop_last = drop_last_train
+  )
   if (!is.null(val_inputs)) {
     val_dataset <- dataset_fn(val_inputs, val_image_inputs, val_outputs)
-    drop_last_val <- should_drop_last_batch(length(val_indices), batch_size, min_last_batch_frac)
-    val_loader  <- dataloader(val_dataset, batch_size = batch_size, shuffle = FALSE, drop_last = drop_last_val)
+    val_loader <- dataloader(
+      val_dataset,
+      batch_size = batch_size,
+      shuffle = FALSE,
+      drop_last = FALSE
+    )
   }
-  # Training loop
-  final_epoch <- NA
-  for (epoch in seq.int(start_epoch, epochs)) {
+  if (resuming && !restore_training_rng_state(checkpoint$rng_state)) {
+    warning("Legacy checkpoint has no RNG state; exact resumption is not possible.")
+  }
+
+  # Training loop. Loss histories are observation-weighted so their values do
+  # not depend on the size of the final batch.
+  completed_epoch <- if (resuming) as.integer(checkpoint$epoch) else 0L
+  epoch_sequence <- if (start_epoch <= epochs) {
+    seq.int(start_epoch, epochs)
+  } else {
+    integer(0)
+  }
+  for (epoch in epoch_sequence) {
     model$train()
-    total_loss  <- 0
-    batch_count <- 0
+    total_loss <- 0
+    train_cases <- 0L
     coro::loop(for (batch in train_loader) {
       optimizer$zero_grad()
       if (length(batch) == 3) {
-        inputs_batch       <- batch[[1]]
+        inputs_batch <- batch[[1]]
         image_inputs_batch <- batch[[2]]
-        outputs_batch      <- batch[[3]]
+        outputs_batch <- batch[[3]]
         pred <- model(inputs_batch, image_inputs_batch)
       } else {
-        inputs_batch  <- batch[[1]]
+        inputs_batch <- batch[[1]]
         outputs_batch <- batch[[2]]
         pred <- model(inputs_batch)
       }
-      loss <- loss_mst_pmdn(pred, outputs_batch,
-                             lambda_alpha = lambda_alpha,
-                             lambda_nu_inv = lambda_nu_inv)
+      loss <- loss_mst_pmdn(
+        pred,
+        outputs_batch,
+        lambda_alpha = lambda_alpha,
+        lambda_nu_inv = lambda_nu_inv
+      )
       loss$backward()
-      if (!is.null(max_norm)) nn_utils_clip_grad_norm_(model$parameters, max_norm)
+      if (!is.null(max_norm))
+        nn_utils_clip_grad_norm_(model$parameters, max_norm)
       optimizer$step()
-      total_loss  <- total_loss + loss$item()
-      batch_count <- batch_count + 1
+      batch_cases <- outputs_batch$size(1)
+      total_loss <- total_loss + loss$item() * batch_cases
+      train_cases <- train_cases + batch_cases
     })
-    avg_train_loss <- total_loss / batch_count
+    if (train_cases == 0)
+      stop("No training cases were evaluated")
+    avg_train_loss <- total_loss / train_cases
     train_loss_history[epoch] <- avg_train_loss
-    # Validation
+    completed_epoch <- epoch
+
     if (!is.null(val_inputs)) {
       model$eval()
       total_val_loss <- 0
-      val_batches    <- 0
+      val_cases <- 0L
       with_no_grad({
         coro::loop(for (batch in val_loader) {
           if (length(batch) == 3) {
-            inputs_batch       <- batch[[1]]
+            inputs_batch <- batch[[1]]
             image_inputs_batch <- batch[[2]]
-            outputs_batch      <- batch[[3]]
+            outputs_batch <- batch[[3]]
             pred <- model(inputs_batch, image_inputs_batch)
           } else {
-            inputs_batch  <- batch[[1]]
+            inputs_batch <- batch[[1]]
             outputs_batch <- batch[[2]]
             pred <- model(inputs_batch)
           }
-          loss <- loss_mst_pmdn(pred, outputs_batch,
-                                 lambda_alpha = lambda_alpha,
-                                 lambda_nu_inv = lambda_nu_inv)
-          total_val_loss <- total_val_loss + loss$item()
-          val_batches    <- val_batches + 1
+          loss <- loss_mst_pmdn(
+            pred,
+            outputs_batch,
+            lambda_alpha = lambda_alpha,
+            lambda_nu_inv = lambda_nu_inv
+          )
+          batch_cases <- outputs_batch$size(1)
+          total_val_loss <- total_val_loss + loss$item() * batch_cases
+          val_cases <- val_cases + batch_cases
         })
       })
-      avg_val_loss <- total_val_loss / val_batches
+      if (val_cases != length(val_indices))
+        stop("Validation loader did not evaluate every validation case")
+      avg_val_loss <- total_val_loss / val_cases
       val_loss_history[epoch] <- avg_val_loss
-      cat(sprintf("Epoch %d - Train Loss: %.4f - Val Loss: %.4f\n", epoch, avg_train_loss, avg_val_loss))
-      # Early stopping logic
+      cat(sprintf(
+        "Epoch %d - Train Loss: %.4f - Val Loss: %.4f\n",
+        epoch, avg_train_loss, avg_val_loss
+      ))
       if (avg_val_loss < best_val_loss) {
-        best_val_loss     <- avg_val_loss
-        best_val_epoch    <- epoch
-        no_improve_epochs <- 0
-        checkpoint <- list(
-          epoch                = epoch,
-          model_state_dict     = model$state_dict(),
-          optimizer_state_dict = optimizer$state_dict(),
-          best_val_loss        = best_val_loss,
-          best_val_epoch       = best_val_epoch,
-          no_improve_epochs    = no_improve_epochs,
-          train_loss_history   = train_loss_history,
-          val_loss_history     = val_loss_history
-        )
-        torch_save(checkpoint, checkpoint_path)
-        cat(sprintf("Checkpoint saved at epoch %d (best_val_loss=%.4f)\n", epoch, best_val_loss))
+        best_val_loss <- avg_val_loss
+        best_val_epoch <- epoch
+        no_improve_epochs <- 0L
+        torch_save(make_checkpoint(epoch), best_checkpoint_path)
+        cat(sprintf(
+          "Best checkpoint saved at epoch %d (best_val_loss=%.4f).\n",
+          epoch, best_val_loss
+        ))
       } else {
-        no_improve_epochs <- no_improve_epochs + 1
-      }
-      if (no_improve_epochs >= early_stopping_patience) {
-        cat(sprintf("Early stopping triggered at epoch %d (no improvement for %d epochs).\n", epoch, early_stopping_patience))
-        final_epoch <- epoch
-        break
-      }
-      # Periodic checkpoint
-      if (epoch %% checkpoint_interval == 0) {
-        checkpoint <- list(
-          epoch                = epoch,
-          model_state_dict     = model$state_dict(),
-          optimizer_state_dict = optimizer$state_dict(),
-          best_val_loss        = best_val_loss,
-          best_val_epoch       = best_val_epoch,
-          no_improve_epochs    = no_improve_epochs,
-          train_loss_history   = train_loss_history,
-          val_loss_history     = val_loss_history
-        )
-        torch_save(checkpoint, checkpoint_path)
-        cat(sprintf("Periodic checkpoint saved at epoch %d.\n", epoch))
-      }
-      # Scheduler step
-      if (!is.null(scheduler_step) && (epoch %% scheduler_step == 0)) {
-        for (group in optimizer$param_groups) group$lr <- group$lr * scheduler_gamma
-        cat(sprintf("Learning rate updated at epoch %d.\n", epoch))
+        no_improve_epochs <- no_improve_epochs + 1L
       }
     } else {
       cat(sprintf("Epoch %d - Train Loss: %.4f\n", epoch, avg_train_loss))
       if (avg_train_loss < best_train_loss) {
-        best_train_loss  <- avg_train_loss
+        best_train_loss <- avg_train_loss
         best_train_epoch <- epoch
-        checkpoint <- list(
-          epoch                = epoch,
-          model_state_dict     = model$state_dict(),
-          optimizer_state_dict = optimizer$state_dict(),
-          best_train_loss      = best_train_loss,
-          best_train_epoch     = best_train_epoch,
-          train_loss_history   = train_loss_history
-        )
-        torch_save(checkpoint, best_train_checkpoint_path)
-        cat(sprintf("Best training checkpoint saved at epoch %d (loss=%.4f)\n", epoch, best_train_loss))
-      }
-      if (epoch %% checkpoint_interval == 0) {
-        checkpoint <- list(
-          epoch                = epoch,
-          model_state_dict     = model$state_dict(),
-          optimizer_state_dict = optimizer$state_dict(),
-          best_train_loss      = best_train_loss,
-          best_train_epoch     = best_train_epoch,
-          train_loss_history   = train_loss_history
-        )
-        torch_save(checkpoint, checkpoint_path)
-        cat(sprintf("Periodic checkpoint saved at epoch %d.\n", epoch))
-      }
-      if (!is.null(scheduler_step) && (epoch %% scheduler_step == 0)) {
-        for (group in optimizer$param_groups) group$lr <- group$lr * scheduler_gamma
-        cat(sprintf("Learning rate updated at epoch %d.\n", epoch))
+        torch_save(make_checkpoint(epoch), best_train_checkpoint_path)
+        cat(sprintf(
+          "Best training checkpoint saved at epoch %d (loss=%.4f).\n",
+          epoch, best_train_loss
+        ))
       }
     }
-  } # End epoch loop
-  if (is.na(final_epoch)) final_epoch <- if (exists("epoch")) epoch else epochs
-  # Reload best checkpoint
-  if (!is.null(val_inputs) && file.exists(checkpoint_path)) {
-    checkpoint <- torch_load(checkpoint_path)
-    model$load_state_dict(checkpoint$model_state_dict)
-    cat("Best model loaded from validation-based checkpoint.\n")
-    best_val_loss     <- checkpoint$best_val_loss
-    best_val_epoch    <- checkpoint$best_val_epoch
-  } else if (is.null(val_inputs) && file.exists(best_train_checkpoint_path)) {
-    checkpoint <- torch_load(best_train_checkpoint_path)
-    model$load_state_dict(checkpoint$model_state_dict)
-    cat("Best model loaded from training-based checkpoint.\n")
-    best_train_loss  <- checkpoint$best_train_loss
-    best_train_epoch <- checkpoint$best_train_epoch
+
+    # Apply the scheduled decay before saving the resumable state so the
+    # restored optimizer has the learning rate for the following epoch.
+    if (!is.null(scheduler_step) && epoch %% scheduler_step == 0) {
+      for (group in optimizer$param_groups)
+        group$lr <- group$lr * scheduler_gamma
+      cat(sprintf("Learning rate updated at epoch %d.\n", epoch))
+    }
+    if (epoch %% checkpoint_interval == 0) {
+      torch_save(make_checkpoint(epoch), checkpoint_path)
+      cat(sprintf("Latest checkpoint saved at epoch %d.\n", epoch))
+    }
+    if (!is.null(val_inputs) &&
+        no_improve_epochs >= early_stopping_patience) {
+      torch_save(make_checkpoint(epoch), checkpoint_path)
+      cat(sprintf(
+        paste0("Early stopping triggered at epoch %d ",
+               "(no improvement for %d epochs).\n"),
+        epoch, early_stopping_patience
+      ))
+      break
+    }
   }
+
+  final_epoch <- completed_epoch
+  if (final_epoch < 1)
+    stop("No training epoch is available")
+  # Always leave a current, resumable checkpoint before loading the best model.
+  torch_save(make_checkpoint(final_epoch), checkpoint_path)
+
+  if (!is.null(val_inputs) && file.exists(best_checkpoint_path)) {
+    best_checkpoint <- torch_load(best_checkpoint_path)
+    model$load_state_dict(best_checkpoint$model_state_dict)
+    best_val_loss <- best_checkpoint$best_val_loss
+    best_val_epoch <- best_checkpoint$best_val_epoch
+    cat("Best model loaded from validation-based checkpoint.\n")
+  } else if (is.null(val_inputs) &&
+             file.exists(best_train_checkpoint_path)) {
+    best_checkpoint <- torch_load(best_train_checkpoint_path)
+    model$load_state_dict(best_checkpoint$model_state_dict)
+    best_train_loss <- best_checkpoint$best_train_loss
+    best_train_epoch <- best_checkpoint$best_train_epoch
+    cat("Best model loaded from training-based checkpoint.\n")
+  } else {
+    warning("No best-model checkpoint was available; returning the latest model.")
+  }
+
   list(
-    model              = model,
-    train_loss_history = train_loss_history[1:final_epoch],
-    val_loss_history   = if (!is.null(val_inputs)) val_loss_history[1:final_epoch] else NULL,
-    best_val_epoch     = best_val_epoch,
-    best_val_loss      = if (!is.null(val_inputs)) best_val_loss else NULL,
-    best_train_epoch   = if (is.null(val_inputs)) best_train_epoch else NULL,
-    best_train_loss    = if (is.null(val_inputs)) best_train_loss else NULL,
-    final_epoch        = final_epoch,
-    train_indices      = train_indices,
-    val_indices        = val_indices
+    model = model,
+    train_loss_history = train_loss_history[seq_len(final_epoch)],
+    val_loss_history = if (!is.null(val_inputs)) {
+      val_loss_history[seq_len(final_epoch)]
+    } else {
+      NULL
+    },
+    best_val_epoch = best_val_epoch,
+    best_val_loss = if (!is.null(val_inputs)) best_val_loss else NULL,
+    best_train_epoch = if (is.null(val_inputs)) best_train_epoch else NULL,
+    best_train_loss = if (is.null(val_inputs)) best_train_loss else NULL,
+    final_epoch = final_epoch,
+    train_indices = train_indices,
+    val_indices = val_indices,
+    checkpoint_path = checkpoint_path,
+    best_checkpoint_path = if (!is.null(val_inputs)) {
+      best_checkpoint_path
+    } else {
+      best_train_checkpoint_path
+    }
   )
 }
 
@@ -1524,40 +1751,63 @@ predict_mst_pmdn <- function(model, new_inputs, image_inputs = NULL,
   }
 }
 
-scov_mst_pmdn <- function(pred, type = c("cov", "scale_chol"),
+scov_mst_pmdn <- function(pred, type = c("scale", "scale_chol", "cov"),
                           as_array = FALSE) {
-  # Compute scale or covariance matrix for each component
-  # from list returned by predict_mst_pmdn
-  # type: "cov" for covariance, "scale_chol" for its Cholesky factor
+  # Compute the scale matrix, its Cholesky factor, or the actual component
+  # covariance matrix from a list returned by predict_mst_pmdn.
   # as_array: TRUE to return an R array instead of a torch_tensor
   type <- match.arg(type)
-  L_val    <- pred$L      # [B, M, 1, 1]   (volume)
-  A_diag   <- pred$A      # [B, M, d]      (shape, diagonal)
-  D_tensor <- pred$D      # [B, M, d, d]   (orientation)
-  device <- L_val$device
-  A_diag   <- A_diag$to(device = device)
-  D_tensor <- D_tensor$to(device = device)
-  B <- L_val$size(1)
-  M <- L_val$size(2)
-  d <- A_diag$size(3)
-  L_val  <- torch_clamp(L_val,  min = 1e-12)
-  A_diag <- torch_clamp(A_diag, min = 1e-12)
-  lambda_half <- torch_sqrt(L_val)                # [B, M, 1, 1]
-  sqrtA       <- torch_sqrt(A_diag)               # [B, M, d]
-  sqrtA_mats  <- torch_diag_embed(sqrtA)          # [B, M, d, d]
-  # Cholesky-like factor from LAD
-  L_direct <- torch_matmul(D_tensor, sqrtA_mats)  # [B, M, d, d]
-  L_direct <- lambda_half * L_direct              # [B, M, d, d]
-  # Scale or covariance matrix
-  Sigma <- torch_matmul(L_direct,
-                        L_direct$transpose(-2L, -1L))  # [B, M, d, d]
-  if (type == "cov") {
-    out <- Sigma
-  } else {  # "scale_chol"
-    out <- linalg_cholesky(Sigma)
+  required_fields <- c("scale_chol", "nu", "alpha")
+  if (!all(required_fields %in% names(pred))) {
+    stop("pred must contain scale_chol, nu, and alpha.")
+  }
+  scale_chol <- pred$scale_chol
+  device <- scale_chol$device
+  nu <- pred$nu$to(device = device)
+  alpha <- pred$alpha$to(device = device)
+  d <- scale_chol$size(3)
+  if (type == "scale_chol") {
+    out <- scale_chol
+  } else {
+    scale <- torch_matmul(
+      scale_chol,
+      scale_chol$transpose(-2L, -1L)
+    )
+    if (type == "scale") {
+      out <- scale
+    } else {
+      # For the canonical skew-t representation used by the likelihood,
+      # delta = alpha / sqrt(1 + alpha^T alpha) and
+      # Cov(Y) = C [nu/(nu-2) I - b_nu^2 delta delta^T] C^T,
+      # where C is scale_chol and
+      # b_nu = sqrt(nu/pi) Gamma((nu-1)/2) / Gamma(nu/2).
+      invalid <- nu <= 2
+      if (invalid$any()$item()) {
+        warning("Component covariance is undefined for nu <= 2; returning NaN for those components.")
+      }
+      nu_safe <- nu$clamp(min = 2 + 1e-6)
+      alpha_norm_sq <- alpha$pow(2)$sum(dim = -1, keepdim = TRUE)
+      delta <- alpha / torch_sqrt(1 + alpha_norm_sq)
+      log_b_nu <- 0.5 * (torch_log(nu_safe) -
+        torch_log(torch_tensor(pi, device = device, dtype = nu_safe$dtype))) +
+        torch_lgamma((nu_safe - 1) / 2) - torch_lgamma(nu_safe / 2)
+      b_nu_sq <- torch_exp(2 * log_b_nu)$unsqueeze(-1)$unsqueeze(-1)
+      eye_mat <- torch_eye(d, device = device, dtype = scale_chol$dtype)$
+        unsqueeze(1)$unsqueeze(1)$expand(scale_chol$size())
+      delta_outer <- delta$unsqueeze(-1) * delta$unsqueeze(-2)
+      standardized_cov <-
+        (nu_safe / (nu_safe - 2))$unsqueeze(-1)$unsqueeze(-1) * eye_mat -
+        b_nu_sq * delta_outer
+      out <- torch_matmul(
+        torch_matmul(scale_chol, standardized_cov),
+        scale_chol$transpose(-2L, -1L)
+      )
+      invalid_expanded <- invalid$unsqueeze(-1)$unsqueeze(-1)$expand(out$size())
+      out <- out$masked_fill(invalid_expanded, NaN)
+    }
   }
   if (as_array) {
-    out <- as_array(out$to(device = "cpu"))
+    out <- torch::as_array(out$to(device = "cpu"))
   }
   out
 }

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 In an MST-PMDN model, parameters of a mixture of multivariate skew t distributions that describe a multivariate output are estimated by training a deep learning model with two multi-modal input branches, one for tabular inputs and the other for (optional) image inputs. The two branches are provided as user-defined ['torch'](https://torch.mlverse.org/) modules. Outputs from each are concatenated and passed through a dense fusion network unless a custom fusion module is supplied, which then leads to the MST-PMDN head. In the absence of both branches, the tabular inputs are fed directly into the dense network. The overall network architecture is [shown here](deep-MST-PMDN.png).
 
-Following the approach used in model-based clustering (['mclust'](https://cran.r-project.org/package=mclust)), scale matrices in the MST-PMDN head are represented using an LAD eigen-decomposition parameterization. LAD attributes, the nu (or degrees of freedom) parameter (n), and the alpha (or skewness) parameter (s) can be forced to be `"V"`ariable or `"E"`qual between mixture components (plus `"I"`dentity for A and D). For n and s parameters, the model can also be constrained to emulate a multivariate `"N"`ormal (or Gaussian) distribution. Different model types are specified by setting the argument `constraint = "EIINN"`, `"VEVEV"`, etc. where each letter position in the argument corresponds, respectively, to each of the LADns attributes. In the case of n, users can specify `"F"`ixed values for nu and pass a `fixed_nu` vector as an additional argument. If an element of `fixed_nu` is set to `NA`, then the value of nu for this component is learned by the network. Furthermore, values of  mu (or means) (m), pi (or mixing coefficients) (x), volume-shape-orientation attributes (LAD), nu (n), and skewness (s) for the mixtures can be made to be independent of inputs by specifying any combination of `constant_attr = "m"`, `"mx"`, ..., `"LADmxns"`.
+Following the approach used in model-based clustering (['mclust'](https://cran.r-project.org/package=mclust)), scale matrices in the MST-PMDN head are represented using an LAD eigen-decomposition parameterization. LAD attributes, the nu (or degrees of freedom) parameter (n), and the alpha (or skewness) parameter (s) can be forced to be `"V"`ariable or `"E"`qual between mixture components (plus `"I"`dentity for A and D). For n and s parameters, the model can also be constrained to emulate a multivariate `"N"`ormal (or Gaussian) distribution. Different model types are specified by setting the argument `constraint = "EIINN"`, `"VEVEV"`, etc. where each letter position in the argument corresponds, respectively, to each of the LADns attributes. In the case of n, users can specify `"F"`ixed values for nu and pass a `fixed_nu` vector as an additional argument. If an element of `fixed_nu` is set to `NA`, then the value of nu for this component is learned by the network. Furthermore, values of mu (the skew-t location parameter) (m), pi (or mixing coefficients) (x), volume-shape-orientation attributes (LAD), nu (n), and skewness (s) for the mixtures can be made to be independent of inputs by specifying any combination of `constant_attr = "m"`, `"mx"`, ..., `"LADmxns"`. When skewness is nonzero, mu is not the component mean.
 
 By combining appropriate values of `constraint` and `constant_attr`, MST-PMDN can emulate the Gaussian finite mixture models implemented by ['mclust'](https://cran.r-project.org/package=mclust), i.e., for unconditional density estimation or model-based clustering:
 
@@ -301,7 +301,7 @@ The deep MST-PMDN implementation consists of the following key functions and mod
 
 #### Function: `init_mu_kmeans(model, outputs_train, ...)`
 
-*   **Purpose:** Initializes the component mean parameters (`mu`) using k-means clustering.
+*   **Purpose:** Initializes the component location parameters (`mu`) using k-means clustering.
 *   **Method:** Applies k-means to the training output data to find initial centroids. These centroids initialize either the `model$mu` parameters (if constant) or the bias of the `model$fc_mu` layer (if network-dependent), setting initial weights to zero.
 *   **Context:** A heuristic to provide a potentially better starting point for training compared to random initialization, aiming for faster convergence.
 
@@ -391,7 +391,7 @@ The deep MST-PMDN implementation consists of the following key functions and mod
 #### Function: `train_mst_pmdn(...)`
 
 *   **Purpose:** Manages the model training process.
-*   **Method:** Includes data loading, model/optimizer setup (with k-means init), training loop (loss calculation, backpropagation, optimization), validation, learning rate scheduling, checkpointing, and early stopping. Handles optional image inputs correctly and allows weighting an L2 penalty on `alpha` through `lambda_alpha` and on `(1/nu)^2` through `lambda_nu_inv`.
+*   **Method:** Includes data loading, model/optimizer setup (with k-means init), training loop (loss calculation, backpropagation, optimization), complete-case validation, learning rate scheduling, checkpointing, and early stopping. The latest resumable state is stored at `checkpoint_path`; the best model is stored separately at a derived `_best` path. Resumption restores the saved split, optimizer, histories, counters, and available R/torch RNG states. Handles optional image inputs and allows weighting an L2 penalty on `alpha` through `lambda_alpha` and on `(1/nu)^2` through `lambda_nu_inv`.
 *   **Output:** Trained model, loss history, and training/validation indices.
 
 #### Function: `predict_mst_pmdn(model, new_inputs, ...)`
@@ -400,14 +400,11 @@ The deep MST-PMDN implementation consists of the following key functions and mod
 *   **Method:** Runs a forward pass on new inputs in evaluation mode (`torch_no_grad()`).
 *   **Output:** Raw model output list containing mixture parameters for the new inputs.
 
-#### Function: `scov_mst_pmdn(pred, type = c("cov", "scale_chol"), ...)`
+#### Function: `scov_mst_pmdn(pred, type = c("scale", "scale_chol", "cov"), ...)`
 
-*   **Purpose:** Converts the volume-shape-orientation decomposition (`L`, `A`, `D`) from `predict_mst_pmdn` into full
-    scale or covariance matrices or their Cholesky factors for each mixture component.
-*   **Method:** Reconstructs the scale matrix via `L^{1/2} * D * sqrt(A)` and optionally computes the Cholesky factor of the
-    resulting covariance.
-*   **Output:** A 4D tensor (or R array if `as_array = TRUE`) of shape `[batch_size, M, d, d]` containing covariance matrices or
-    Cholesky factors.
+*   **Purpose:** Returns component scale matrices, their Cholesky factors, or actual skew-t covariance matrices.
+*   **Method:** Uses the `scale_chol` factor employed by the likelihood. For `type = "cov"`, the scale is transformed using both `nu` and `alpha`; covariance is undefined for `nu <= 2`.
+*   **Output:** A 4D tensor (or R array if `as_array = TRUE`) of shape `[batch_size, M, d, d]`. The default `type = "scale"` retains the numerical output returned by earlier versions under the misleading name `"cov"`.
 
 
 ## References

--- a/man/cdf_marginal_mst_pmdn.Rd
+++ b/man/cdf_marginal_mst_pmdn.Rd
@@ -38,7 +38,7 @@ For comparable results across chained sampling-based summaries, either pass the 
 \code{seed} to each call or reuse identical \code{draws}.
 }
 \value{
-A numeric vector of estimated marginal CDF values, aligned with \code{y}.
+A \code{torch_tensor} of estimated marginal CDF values with rows aligned to the prediction batch and columns aligned to the selected output dimensions.
 }
 \seealso{
 \code{\link{quantile_marginal_mst_pmdn}}, \code{\link{sample_mst_pmdn}}

--- a/man/define_mst_pmdn.Rd
+++ b/man/define_mst_pmdn.Rd
@@ -32,7 +32,7 @@ define_mst_pmdn(
   \item{hidden_dim}{Integer vector. Sizes of hidden layers in the dense fusion network.}
   \item{n_mixtures}{Integer. Number of skew t mixture components \code{M}.}
   \item{constraint}{Character. Code for volume–shape–orientation, degrees of freedom \code{nu}, and skew constraints (e.g., “\code{VVVFN}”).}
-  \item{constant_attr}{Character. Flags for parameters held constant (e.g., “\code{m}” for means, “\code{s}” for skew, etc.).}
+  \item{constant_attr}{Character. Flags for parameters held constant (e.g., “\code{m}” for skew-t locations, “\code{s}” for skew, etc.).}
   \item{activation}{Function. \pkg{torch} activation for hidden layers (default \code{nn_relu}).}
   \item{drop_hidden}{Numeric between 0 and 1. Dropout probability after each hidden layer; when \code{fusion_module} is provided, this dropout is applied to the fusion output.}
   \item{image_module}{A \pkg{torch} \code{nn_module} for image feature extraction, or \code{NULL} to omit.}

--- a/man/loss_mst_pmdn.Rd
+++ b/man/loss_mst_pmdn.Rd
@@ -13,7 +13,7 @@ loss_mst_pmdn(output, target, lambda_alpha = 0, lambda_nu_inv = 0)
 }
 \description{
 Computes the average negative log-likelihood under a mixture of multivariate skew t distributions for a batch of examples.
-The function extracts mixture weights, component means, Cholesky scale factors, degrees of freedom, and skewness parameters from \code{output}, then evaluates the MST-PMDN log-density at \code{target}, finally averaging (and negating) to produce the loss.
+The function extracts mixture weights, component locations, Cholesky scale factors, degrees of freedom, and skewness parameters from \code{output}, then evaluates the MST-PMDN log-density at \code{target}, finally averaging (and negating) to produce the loss.
 }
 \value{
 A single-element \code{\link[torch]{torch_tensor}} containing the batch-averaged negative log-likelihood.

--- a/man/mst-pmdn-package.Rd
+++ b/man/mst-pmdn-package.Rd
@@ -34,7 +34,7 @@ respectively, to each of the LADns attributes. In the case of n, users
 can specify \code{"F"}ixed values for nu by passing an optional \code{fixed_nu} 
 vector. If an element of \code{fixed_nu} is set to \code{NA}, then the value 
 of nu for this component is learned by the network. Furthermore, values of mu (or 
-means) (m), pi (or mixing coefficients) (x), volume-shape-orientation 
+skew-t locations) (m), pi (or mixing coefficients) (x), volume-shape-orientation
 attributes (LAD), nu (n), and skewness (s) for the mixtures can be made to 
 be independent of inputs by specifying any combination of 
 \code{constant_attr = "m"}, \code{"mx"}, ..., \code{"LADmxns"}.

--- a/man/predict_mst_pmdn.Rd
+++ b/man/predict_mst_pmdn.Rd
@@ -19,7 +19,7 @@ predict_mst_pmdn(model, new_inputs, image_inputs = NULL, device = "cpu")
 A named \code{list} containing the output of the model’s forward pass:
 \describe{
   \item{\code{pi}}{Mixture weights tensor of shape \code{[batch_size, M]}.}
-  \item{\code{mu}}{Component means tensor of shape \code{[batch_size, M, d]}.}
+  \item{\code{mu}}{Component skew-t location tensor of shape \code{[batch_size, M, d]}. This is not the component mean when skewness is nonzero.}
   \item{\code{scale_chol}}{Cholesky scale factors tensor of shape \code{[batch_size, M, d, d]}.}
   \item{\code{nu}}{Degrees-of-freedom tensor of shape \code{[batch_size, M]}.}
   \item{\code{alpha}}{Skewness parameters tensor of shape \code{[batch_size, M, d]}.}

--- a/man/scov_mst_pmdn.Rd
+++ b/man/scov_mst_pmdn.Rd
@@ -1,26 +1,35 @@
 \name{scov_mst_pmdn}
 \alias{scov_mst_pmdn}
-\title{Derive component covariance or scale matrices from MST-PMDN predictions}
+\title{Derive component scale or covariance matrices from MST-PMDN predictions}
 \description{
-Transforms the volume-shape-orientation decomposition returned by
-\code{\link{predict_mst_pmdn}} into full scale/covariance matrices or their Cholesky
-factors for each mixture component.
+Returns full scale matrices, their Cholesky factors, or actual component
+covariance matrices from \code{\link{predict_mst_pmdn}} output.
 }
 \usage{
-scov_mst_pmdn(pred, type = c("cov", "scale_chol"), as_array = FALSE)
+scov_mst_pmdn(pred, type = c("scale", "scale_chol", "cov"), as_array = FALSE)
 }
 \arguments{
   \item{pred}{List output from \code{\link{predict_mst_pmdn}} containing
-  elements \code{L}, \code{A}, and \code{D} for the volume, diagonal shape,
-  and orientation matrices.}
-  \item{type}{Character; set to \code{"cov"} to return covariance matrices
-  \eqn{\Sigma = L^{1/2} D \sqrt{A} (L^{1/2} D \sqrt{A})^T} or
-  \code{"scale_chol"} to return their Cholesky factors.}
+  \code{scale_chol}, \code{nu}, and \code{alpha}.}
+  \item{type}{Character; \code{"scale"} returns the skew-t scale matrix,
+  \code{"scale_chol"} returns its Cholesky factor, and \code{"cov"} returns
+  the component covariance after accounting for degrees of freedom and
+  skewness. Component covariance is undefined for \eqn{\nu \le 2}.}
   \item{as_array}{Logical; if \code{TRUE}, converts the result to a base R
   array on CPU. Otherwise returns a \code{torch_tensor} on the original device.}
 }
 \value{
 A 4D \code{torch_tensor} (or base R array if \code{as_array = TRUE}) of shape
-\code{[batch_size, M, d, d]} containing either scale/covariance matrices or their
-Cholesky factors for each of the \code{M} mixture components.
+\code{[batch_size, M, d, d]} containing scale matrices, Cholesky factors, or
+component covariance matrices. Entries for \code{type = "cov"} are \code{NaN}
+where \eqn{\nu \le 2}.
+}
+\details{
+Let \eqn{C} denote \code{scale_chol},
+\eqn{\delta = \alpha / \sqrt{1 + \alpha^T\alpha}}, and
+\deqn{b_\nu = \sqrt{\nu/\pi}\,\Gamma((\nu-1)/2)/\Gamma(\nu/2).}
+For \eqn{\nu>2}, the component covariance is
+\deqn{C\left[\frac{\nu}{\nu-2}I-b_\nu^2\delta\delta^T\right]C^T.}
+The default \code{type = "scale"} retains the numerical default returned by
+versions prior to 0.2.0, where it was incorrectly labelled covariance.
 }

--- a/man/train_mst_pmdn.Rd
+++ b/man/train_mst_pmdn.Rd
@@ -51,7 +51,7 @@ train_mst_pmdn(
   \item{hidden_dim}{Integer vector giving the sizes of the hidden layers in the fusion network.}
   \item{n_mixtures}{Integer; number of mixture components \code{M}.}
   \item{constraint}{Character; MST-PMDN constraint code (volume–shape–orientation, degrees of freedon \code{nu}, and skew), e.g. \code{"VVVFN"}.}
-  \item{constant_attr}{Character; flags for parameters held constant ("m" for means, "x" for mixing coefficients, "L" for volume, "A" for shape, "D" for orientation, "n" for degrees of freedom \code{nu}, and "s" for skew).}
+  \item{constant_attr}{Character; flags for parameters held constant ("m" for skew-t locations, "x" for mixing coefficients, "L" for volume, "A" for shape, "D" for orientation, "n" for degrees of freedom \code{nu}, and "s" for skew).}
   \item{fixed_nu}{Numeric vector of length \code{M}, or \code{NULL}; if non-\code{NULL}, fixes degrees of freedom \code{nu} per component.}
   \item{range_nu}{Numeric vector of length 2: clamp range for \code{nu}. Defaults to \code{c(3, 500)} so the normal approximation used in the tails remains accurate.}
   \item{max_alpha}{Numeric; maximum absolute skewness parameter.}
@@ -69,8 +69,8 @@ train_mst_pmdn(
   \item{wd_image}{Numeric; weight decay (L2 penalty) for \code{image_module} parameters.}
   \item{wd_tabular}{Numeric; weight decay for \code{tabular_module} parameters.}
   \item{checkpoint_interval}{Integer; number of epochs between saved checkpoints.}
-  \item{checkpoint_path}{Character; file path for saving model checkpoints.}
-  \item{resume_from_checkpoint}{Logical; if \code{TRUE}, loads and resumes from an existing checkpoint.}
+  \item{checkpoint_path}{Character; file path for the latest resumable training state. The best validation model is saved separately using a derived \code{_best} path.}
+  \item{resume_from_checkpoint}{Logical; if \code{TRUE}, restores the model, optimizer, split, histories, counters, and available RNG states from \code{checkpoint_path}.}
   \item{model}{An existing \code{mst_pmdn_model} to continue training, or \code{NULL} to initialize a new one.}
   \item{early_stopping_patience}{Integer; epochs with no validation improvement before stopping.}
   \item{validation_split}{Numeric in [0,1]; fraction of cases held out for validation if \code{custom_split} is \code{NULL}.}
@@ -81,13 +81,13 @@ train_mst_pmdn(
   \item{image_module}{Optional \code{nn_module} for processing \code{image_inputs}.}
   \item{tabular_module}{Optional \code{nn_module} for processing \code{inputs}.}
   \item{fusion_module}{Optional \code{nn_module} for fusing tabular and image features before the MST-PMDN head.}
-  \item{min_last_batch_frac}{Numeric in [0,1]; drop the final incomplete mini-batch (for both training and validation loaders) only when its size is smaller than \code{ceiling(batch_size * min_last_batch_frac)}.}
+  \item{min_last_batch_frac}{Numeric in [0,1]; drop the final incomplete training mini-batch only when its size is smaller than \code{ceiling(batch_size * min_last_batch_frac)}. Validation always evaluates every case.}
   \item{device}{Character; torch device to use (e.g., \code{"cpu"} or \code{"cuda"}).}
 }
 \details{
 Splits the data into training/validation sets (unless \code{custom_split} is provided), initializes or loads the model,
 and then runs an Adam optimization loop with optional gradient clipping, weight decay, dropout, early stopping, checkpointing,
-and learning-rate scheduling.  After training, the best‐performing model (by validation or training loss) is reloaded before returning. 
+and learning-rate scheduling. Training and validation histories are observation-weighted rather than batch-weighted. The latest resumable state and best-performing model are stored separately, and the best model (by validation or training loss) is reloaded before returning.
 }
 \value{
 A \code{list} with components:
@@ -102,5 +102,7 @@ A \code{list} with components:
   \item{final_epoch}{Last completed epoch.}
   \item{train_indices}{Indices of cases used for training.}
   \item{val_indices}{Indices of cases used for validation.}
+  \item{checkpoint_path}{Path containing the latest resumable training state.}
+  \item{best_checkpoint_path}{Path containing the best validation- or training-loss model.}
 }
 }

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(MST.PMDN)
+
+test_check("MST.PMDN")

--- a/tests/testthat/helper-prediction.R
+++ b/tests/testthat/helper-prediction.R
@@ -1,0 +1,23 @@
+make_mdn_output <- function(pi, mu, scale_chol, nu, alpha) {
+  list(
+    pi = torch::torch_tensor(pi, dtype = torch::torch_float()),
+    mu = torch::torch_tensor(mu, dtype = torch::torch_float()),
+    scale_chol = torch::torch_tensor(
+      scale_chol, dtype = torch::torch_float()
+    ),
+    nu = torch::torch_tensor(nu, dtype = torch::torch_float()),
+    alpha = torch::torch_tensor(alpha, dtype = torch::torch_float())
+  )
+}
+
+expect_state_dict_equal <- function(x, y, tolerance = 1e-6) {
+  expect_setequal(names(x), names(y))
+  for (name in names(x)) {
+    expect_equal(
+      torch::as_array(x[[name]]$cpu()),
+      torch::as_array(y[[name]]$cpu()),
+      tolerance = tolerance,
+      info = name
+    )
+  }
+}

--- a/tests/testthat/test-distribution-summaries.R
+++ b/tests/testthat/test-distribution-summaries.R
@@ -1,0 +1,77 @@
+test_that("marginal CDF is the empirical proportion", {
+  pred <- make_mdn_output(
+    pi = matrix(1, 1, 1),
+    mu = array(0, c(1, 1, 1)),
+    scale_chol = array(1, c(1, 1, 1, 1)),
+    nu = matrix(10, 1, 1),
+    alpha = array(0, c(1, 1, 1))
+  )
+  draws <- array(seq_len(10), dim = c(10, 1, 1))
+
+  expect_equal(
+    as.numeric(cdf_marginal_mst_pmdn(pred, 5, draws = draws)),
+    0.5
+  )
+  expect_equal(
+    as.numeric(cdf_marginal_mst_pmdn(pred, 0, draws = draws)),
+    0
+  )
+  expect_equal(
+    as.numeric(cdf_marginal_mst_pmdn(pred, 10, draws = draws)),
+    1
+  )
+})
+
+test_that("scov distinguishes scale and covariance", {
+  chol <- matrix(c(2, 0, 0.5, 1), 2, 2, byrow = TRUE)
+  scale <- chol %*% t(chol)
+  pred <- make_mdn_output(
+    pi = matrix(1, 1, 1),
+    mu = array(0, c(1, 1, 2)),
+    scale_chol = array(chol, c(1, 1, 2, 2)),
+    nu = matrix(10, 1, 1),
+    alpha = array(0, c(1, 1, 2))
+  )
+
+  expect_equal(scov_mst_pmdn(pred, as_array = TRUE)[1, 1, , ], scale,
+               tolerance = 1e-6)
+  expect_equal(
+    scov_mst_pmdn(pred, type = "scale_chol", as_array = TRUE)[1, 1, , ],
+    chol,
+    tolerance = 1e-6
+  )
+  expect_equal(
+    scov_mst_pmdn(pred, type = "cov", as_array = TRUE)[1, 1, , ],
+    10 / 8 * scale,
+    tolerance = 1e-5
+  )
+})
+
+test_that("skew-t covariance uses nu and alpha", {
+  nu <- 12
+  alpha_vec <- c(1, -0.5)
+  delta <- alpha_vec / sqrt(1 + sum(alpha_vec^2))
+  b_nu <- sqrt(nu / pi) * gamma((nu - 1) / 2) / gamma(nu / 2)
+  expected <- nu / (nu - 2) * diag(2) -
+    b_nu^2 * tcrossprod(delta)
+  pred <- make_mdn_output(
+    pi = matrix(1, 1, 1),
+    mu = array(0, c(1, 1, 2)),
+    scale_chol = array(diag(2), c(1, 1, 2, 2)),
+    nu = matrix(nu, 1, 1),
+    alpha = array(alpha_vec, c(1, 1, 2))
+  )
+
+  expect_equal(
+    scov_mst_pmdn(pred, type = "cov", as_array = TRUE)[1, 1, , ],
+    expected,
+    tolerance = 1e-5
+  )
+
+  pred$nu <- torch::torch_tensor(matrix(2, 1, 1))
+  expect_warning(
+    invalid <- scov_mst_pmdn(pred, type = "cov", as_array = TRUE),
+    "undefined"
+  )
+  expect_true(all(is.nan(invalid)))
+})

--- a/tests/testthat/test-initialization.R
+++ b/tests/testthat/test-initialization.R
@@ -1,0 +1,23 @@
+test_that("specialized nu and alpha initialization survives generic initialization", {
+  torch::torch_manual_seed(7)
+  model <- define_mst_pmdn(
+    input_dim = 2,
+    output_dim = 2,
+    hidden_dim = c(4),
+    n_mixtures = 2,
+    constraint = "VIIVV",
+    range_nu = c(3, 103)
+  )
+  model$apply(MST.PMDN:::init_weight_norm)
+  MST.PMDN:::init_distribution_heads(model)
+  x <- torch::torch_tensor(
+    matrix(c(-2, 1, 4, -3), nrow = 2, byrow = TRUE),
+    dtype = torch::torch_float()
+  )
+  pred <- model(x)
+  nu <- torch::as_array(pred$nu)
+  alpha <- torch::as_array(pred$alpha)
+
+  expect_equal(nu, matrix(53, nrow = 2, ncol = 2), tolerance = 1e-6)
+  expect_equal(alpha, array(0, dim = c(2, 2, 2)), tolerance = 1e-6)
+})

--- a/tests/testthat/test-sampling.R
+++ b/tests/testthat/test-sampling.R
@@ -1,0 +1,67 @@
+test_that("mixture sampling uses one-based component indices exactly once", {
+  B <- 2L
+  M <- 2L
+  d <- 1L
+  pi <- rbind(c(1, 0), c(0, 1))
+  mu <- array(0, dim = c(B, M, d))
+  mu[, 1, 1] <- -2
+  mu[, 2, 1] <- 2
+  scale_chol <- array(0, dim = c(B, M, d, d))
+  scale_chol[, , 1, 1] <- 1
+  nu <- matrix(20, nrow = B, ncol = M)
+  alpha <- array(0, dim = c(B, M, d))
+  pred <- make_mdn_output(pi, mu, scale_chol, nu, alpha)
+
+  set.seed(1)
+  torch::torch_manual_seed(1)
+  sampled <- sample_mst_pmdn(pred, num_samples = 20)
+  components <- torch::as_array(sampled$components)
+
+  expect_true(all(components[, 1] == 1))
+  expect_true(all(components[, 2] == 2))
+  expect_true(all(components >= 1 & components <= M))
+})
+
+test_that("one-component sampling and data-frame formatting work", {
+  pred <- make_mdn_output(
+    pi = matrix(1, 1, 1),
+    mu = array(0, c(1, 1, 1)),
+    scale_chol = array(1, c(1, 1, 1, 1)),
+    nu = matrix(10, 1, 1),
+    alpha = array(0, c(1, 1, 1))
+  )
+
+  expect_no_error(sample_mst_pmdn(pred, num_samples = 3))
+  out <- sample_mst_pmdn_df(pred, num_samples = 3)
+  expect_equal(nrow(out), 3)
+  expect_equal(as.integer(out$comp), rep(1L, 3))
+  expect_error(sample_mst_pmdn(pred, num_samples = 1.5),
+               "positive integer")
+})
+
+test_that("multivariate skew-t samples match analytic moments", {
+  skip_on_cran()
+  nu <- 20
+  alpha_vec <- c(1, 1)
+  delta <- alpha_vec / sqrt(1 + sum(alpha_vec^2))
+  b_nu <- sqrt(nu / pi) * gamma((nu - 1) / 2) / gamma(nu / 2)
+  expected_mean <- b_nu * delta
+  expected_cov <- nu / (nu - 2) * diag(2) -
+    b_nu^2 * tcrossprod(delta)
+  pred <- make_mdn_output(
+    pi = matrix(1, 1, 1),
+    mu = array(0, c(1, 1, 2)),
+    scale_chol = array(diag(2), c(1, 1, 2, 2)),
+    nu = matrix(nu, 1, 1),
+    alpha = array(alpha_vec, c(1, 1, 2))
+  )
+
+  set.seed(42)
+  torch::torch_manual_seed(42)
+  draws <- torch::as_array(
+    sample_mst_pmdn(pred, num_samples = 30000)$samples
+  )[, 1, ]
+
+  expect_equal(colMeans(draws), expected_mean, tolerance = 0.035)
+  expect_equal(stats::cov(draws), expected_cov, tolerance = 0.05)
+})

--- a/tests/testthat/test-training-state.R
+++ b/tests/testthat/test-training-state.R
@@ -1,0 +1,124 @@
+make_small_model <- function() {
+  define_mst_pmdn(
+    input_dim = 2,
+    output_dim = 1,
+    hidden_dim = c(4),
+    n_mixtures = 1,
+    constraint = "VIINN"
+  )
+}
+
+test_that("validation uses every case and is batch-size invariant", {
+  x <- cbind(seq(-1, 1, length.out = 13), seq(1, -1, length.out = 13))
+  y <- matrix(0.5 * x[, 1] - 0.25 * x[, 2], ncol = 1)
+  split <- list(train = 1:7, validation = 8:13)
+
+  torch::torch_manual_seed(11)
+  base_model <- make_small_model()
+  model_a <- make_small_model()
+  model_b <- make_small_model()
+  model_a$load_state_dict(base_model$state_dict())
+  model_b$load_state_dict(base_model$state_dict())
+
+  path_a <- tempfile(fileext = ".pt")
+  path_b <- tempfile(fileext = ".pt")
+  fit_a <- train_mst_pmdn(
+    x, y,
+    hidden_dim = c(4), n_mixtures = 1, constraint = "VIINN",
+    epochs = 1, lr = 0, batch_size = 4,
+    checkpoint_interval = 1, checkpoint_path = path_a,
+    model = model_a, custom_split = split,
+    scheduler_step = NULL, min_last_batch_frac = 0
+  )
+  fit_b <- train_mst_pmdn(
+    x, y,
+    hidden_dim = c(4), n_mixtures = 1, constraint = "VIINN",
+    epochs = 1, lr = 0, batch_size = 5,
+    checkpoint_interval = 1, checkpoint_path = path_b,
+    model = model_b, custom_split = split,
+    scheduler_step = NULL, min_last_batch_frac = 0
+  )
+
+  expect_equal(fit_a$val_loss_history, fit_b$val_loss_history,
+               tolerance = 1e-6)
+  pred <- predict_mst_pmdn(fit_a$model, x[split$validation, , drop = FALSE])
+  manual_loss <- loss_mst_pmdn(
+    pred,
+    torch::torch_tensor(y[split$validation, , drop = FALSE],
+                        dtype = torch::torch_float())
+  )$item()
+  expect_equal(fit_a$val_loss_history[[1]], manual_loss, tolerance = 1e-6)
+  expect_equal(length(fit_a$val_indices), length(split$validation))
+})
+
+test_that("checkpoint resume reproduces uninterrupted training", {
+  skip_on_cran()
+  x <- cbind(seq(-2, 2, length.out = 16), cos(seq_len(16)))
+  y <- matrix(sin(x[, 1]) + 0.2 * x[, 2], ncol = 1)
+  split <- list(train = 1:12, validation = 13:16)
+  full_path <- tempfile(fileext = ".pt")
+  resumed_path <- tempfile(fileext = ".pt")
+
+  common <- list(
+    inputs = x,
+    outputs = y,
+    hidden_dim = c(4),
+    n_mixtures = 1,
+    constraint = "VIINN",
+    lr = 0.005,
+    batch_size = 4,
+    checkpoint_interval = 2,
+    early_stopping_patience = 100,
+    scheduler_step = 2,
+    scheduler_gamma = 0.8,
+    min_last_batch_frac = 0
+  )
+
+  set.seed(101)
+  torch::torch_manual_seed(101)
+  fit_full <- do.call(
+    train_mst_pmdn,
+    c(common, list(
+      epochs = 4,
+      checkpoint_path = full_path,
+      custom_split = split
+    ))
+  )
+
+  set.seed(101)
+  torch::torch_manual_seed(101)
+  do.call(
+    train_mst_pmdn,
+    c(common, list(
+      epochs = 2,
+      checkpoint_path = resumed_path,
+      custom_split = split
+    ))
+  )
+  fit_resumed <- do.call(
+    train_mst_pmdn,
+    c(common, list(
+      epochs = 4,
+      checkpoint_path = resumed_path,
+      resume_from_checkpoint = TRUE
+    ))
+  )
+
+  expect_equal(fit_resumed$train_indices, fit_full$train_indices)
+  expect_equal(fit_resumed$val_indices, fit_full$val_indices)
+  expect_equal(fit_resumed$train_loss_history,
+               fit_full$train_loss_history, tolerance = 1e-6)
+  expect_equal(fit_resumed$val_loss_history,
+               fit_full$val_loss_history, tolerance = 1e-6)
+  expect_state_dict_equal(
+    fit_resumed$model$state_dict(),
+    fit_full$model$state_dict(),
+    tolerance = 1e-6
+  )
+
+  latest <- torch::torch_load(resumed_path)
+  best <- torch::torch_load(fit_resumed$best_checkpoint_path)
+  expect_equal(latest$epoch, 4L)
+  expect_equal(best$epoch, fit_resumed$best_val_epoch)
+  expect_false(identical(resumed_path, fit_resumed$best_checkpoint_path))
+})


### PR DESCRIPTION
## Summary

- correct mixture-component indexing and the multivariate skew-normal construction used by both sampling helpers
- use the empirical proportion for marginal CDF estimates
- distinguish skew-t scale matrices, scale Cholesky factors, and actual component covariance matrices
- preserve neutral learned `nu` and `alpha` initialization
- make checkpoints resumable by restoring optimizer, split, histories, counters, and available R/torch RNG state
- keep latest and best checkpoints in separate files
- evaluate every validation case and report observation-weighted losses
- add regression tests, R CMD check CI, documentation updates, and release notes

## Why

The sampler mixed R and libtorch index conventions and used a scalar residual adjustment instead of the matrix square root required for multivariate skew-normal draws. The CDF estimator applied an incorrect finite-sample correction, while the covariance helper returned a scale matrix under a covariance label.

Training initialization later overwrote the specialized distribution-head initialization. Resume logic could not restore the optimizer because it checked the model after constructing it, best checkpoints shared a path with resumable checkpoints, and validation could drop observations and weight batches equally regardless of size.

## Impact

Sampling now matches the canonical multivariate skew-t moments. Distribution summaries have explicit scale/covariance semantics, and `mu` is documented as a location parameter. Interrupted training can reproduce the saved continuation state, while validation metrics cover the complete holdout set.

## Validation

- parsed all package and test R files successfully with a tree-sitter R grammar
- validated workflow YAML and Rd brace structure
- `git diff --check` passes
- added targeted regression tests for all corrected behaviors

The R test suite was not executed locally because this workspace does not include an R runtime; the new GitHub Actions workflow runs R CMD check with libtorch.