### PR TITLE
Correct network architecture documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,8 +212,8 @@ image_mod <- image_module(
 
 # Define the fusion network, MST-PMDN head, and training setup
 # Note: hyperparameters and number of epochs are not optimized
-hidden_dim <- c(64, 32) # Hidden nodes in fusion network
-drop_hidden <- 0.1      # Dropout for fusion network
+hidden_dim <- c(64, 32) # Layer widths in the default dense MLP
+drop_hidden <- 0.1      # Dropout between non-final MLP layers
 n_mixtures <- 2         # 2 components in the MST mixture model
 constraint <- "VVIFN"   # LAD = "V"ariable-"V"ariable-"I"dentity; nu = 1 component "F"ixed; skewness = "N"ormal
 fixed_nu <- c(500, NA)  # nu = 500 for 1st component (i.e., approximately "N"ormal); "V"ariable for 2nd
@@ -309,7 +309,7 @@ The deep MST-PMDN implementation consists of the following key functions and mod
 
 *   **Purpose:** Implements a linear layer with weight normalization.
 *   **Method:** Decomposes the weight matrix `W` into a direction `V` and a magnitude `g`, learning these instead of `W` directly.
-*   **Context:** Used for most linear layers within the network architecture (hidden layers and parameter prediction heads) to potentially improve training stability and convergence speed.
+*   **Context:** Used for the MST-PMDN parameter-prediction heads. The default hidden MLP uses `nn_linear` layers; each non-final layer is followed by batch normalization, activation, and dropout.
 
 #### Function: `init_weight_norm(module)`
 
@@ -322,7 +322,7 @@ The deep MST-PMDN implementation consists of the following key functions and mod
 *   **Purpose:** Defines the main MST-PMDN neural network architecture.
 *   **Method:**
     *   Processes optional image and tabular inputs through dedicated modules or uses raw inputs.
-    *   Applies an optional fusion module (when provided), followed by an optional dropout, or concatenates features and passes them through a hidden MLP using `weight_norm_linear` layers.
+    *   When a fusion module is supplied, its output receives the optional `drop_hidden` dropout and is passed directly to the parameter-prediction heads. Otherwise, extracted features are concatenated and processed by a default hidden MLP constructed from `nn_linear` layers. In the custom-fusion case, `hidden_dim` creates no hidden layers and its final value is used only as a fallback for determining the fusion output dimension.
     *   Predicts mixture parameters (`pi`, `mu`, `L`, `A`, `D`, `nu`, `alpha`) using separate output heads (mostly `weight_norm_linear` or `nn_parameter` if constant).
     *   Applies constraints (Variable, Equal, Identity, Normal approx., Fixed) to parameters based on configuration.
     *   Constructs the full scale matrix `Sigma = L * D * diag(A) * D^T` and computes its Cholesky decomposition (`scale_chol`) for each component.

--- a/examples/wave-surge-dailymax.R
+++ b/examples/wave-surge-dailymax.R
@@ -371,7 +371,7 @@ fusion_module <- nn_module(
   }
 )
 
-hidden_dim <- c(64, 32)
+hidden_dim <- integer(0) # No default MLP; fusion_mod declares output_dim = 32
 drop_hidden <- 0.2
 fusion_mod <- fusion_module(
   tabular_dim = tabular_mod$output_dim,

--- a/man/define_mst_pmdn.Rd
+++ b/man/define_mst_pmdn.Rd
@@ -29,15 +29,15 @@ define_mst_pmdn(
 \arguments{
   \item{input_dim}{Integer. Number of features in the raw tabular input (used if \code{tabular_module} is \code{NULL}).}
   \item{output_dim}{Integer. Dimension \code{d} of the multivariate response.}
-  \item{hidden_dim}{Integer vector. Sizes of hidden layers in the dense fusion network.}
+  \item{hidden_dim}{Integer vector. Layer widths in the default dense MLP. When \code{fusion_module} is supplied, these values create no layers; the final value is used only if the fusion output dimension cannot be inferred.}
   \item{n_mixtures}{Integer. Number of skew t mixture components \code{M}.}
   \item{constraint}{Character. Code for volume–shape–orientation, degrees of freedom \code{nu}, and skew constraints (e.g., “\code{VVVFN}”).}
   \item{constant_attr}{Character. Flags for parameters held constant (e.g., “\code{m}” for skew-t locations, “\code{s}” for skew, etc.).}
-  \item{activation}{Function. \pkg{torch} activation for hidden layers (default \code{nn_relu}).}
-  \item{drop_hidden}{Numeric between 0 and 1. Dropout probability after each hidden layer; when \code{fusion_module} is provided, this dropout is applied to the fusion output.}
+  \item{activation}{Function or list of functions. \pkg{torch} activation applied after each non-final layer of the default dense MLP (default \code{nn_relu}). Ignored when \code{fusion_module} is supplied.}
+  \item{drop_hidden}{Numeric between 0 and 1. Dropout probability after each non-final layer of the default dense MLP. When \code{fusion_module} is supplied, dropout is applied once to the fusion output.}
   \item{image_module}{A \pkg{torch} \code{nn_module} for image feature extraction, or \code{NULL} to omit.}
   \item{tabular_module}{A \pkg{torch} \code{nn_module} for tabular feature extraction, or \code{NULL} to use raw inputs.}
-  \item{fusion_module}{Optional \pkg{torch} \code{nn_module} that fuses tabular and image features. When provided, it replaces the default concatenation + MLP fusion network.}
+  \item{fusion_module}{Optional \pkg{torch} \code{nn_module} that fuses tabular and image features. When supplied, it bypasses the default dense MLP; after optional \code{drop_hidden} dropout, its output is passed directly to the parameter-prediction heads. The output width is inferred from \code{output_dim}, \code{out_features}, \code{out_channels}, or \code{out_dim}; the final \code{hidden_dim} value is used as a fallback.}
   \item{fixed_nu}{Numeric vector of length \code{M}, or \code{NULL}. If non-\code{NULL}, fixes degrees of freedom for each component.}
   \item{range_nu}{Numeric vector of length 2: \code{c(min_nu, max_nu)} to clamp learned \code{nu}. Defaults to \code{c(3, 500)} to allow a tighter normal approximation in the tails.}
   \item{max_alpha}{Numeric. Absolute bound for skewness parameter.}

--- a/man/train_mst_pmdn.Rd
+++ b/man/train_mst_pmdn.Rd
@@ -48,7 +48,7 @@ train_mst_pmdn(
 \arguments{
   \item{inputs}{Numeric matrix or \code{\link[torch]{torch_tensor}} of predictors (rows = cases).}
   \item{outputs}{Numeric matrix or \code{\link[torch]{torch_tensor}} of responses (rows = cases).}
-  \item{hidden_dim}{Integer vector giving the sizes of the hidden layers in the fusion network.}
+  \item{hidden_dim}{Integer vector giving the layer widths in the default dense MLP. When \code{fusion_module} is supplied, these values create no layers; the final value is used only if the fusion output dimension cannot be inferred.}
   \item{n_mixtures}{Integer; number of mixture components \code{M}.}
   \item{constraint}{Character; MST-PMDN constraint code (volume–shape–orientation, degrees of freedon \code{nu}, and skew), e.g. \code{"VVVFN"}.}
   \item{constant_attr}{Character; flags for parameters held constant ("m" for skew-t locations, "x" for mixing coefficients, "L" for volume, "A" for shape, "D" for orientation, "n" for degrees of freedom \code{nu}, and "s" for skew).}
@@ -58,14 +58,14 @@ train_mst_pmdn(
   \item{min_vol_shape}{Numeric; minimum allowed volume (L) and shape (A) diagonal values.}
   \item{min_mix_weight}{Numeric; minimum mixture weight per component.}
   \item{jitter}{Numeric; small ridge added to covariance diagonals for stability.}
-  \item{activation}{Activation function for hidden layers (e.g., \code{nn_tanh}, \code{nn_relu}).}
+  \item{activation}{Function or list of functions applied after each non-final layer of the default dense MLP (e.g., \code{nn_tanh}, \code{nn_relu}). Ignored when \code{fusion_module} is supplied.}
   \item{lambda_alpha}{Numeric; weight of an L2 penalty on the final skewness parameter \code{alpha}.}
   \item{lambda_nu_inv}{Numeric; weight of a penalty on \code{(1/nu)^2}.}
   \item{epochs}{Integer; maximum number of training epochs.}
   \item{lr}{Numeric; learning rate for the optimizer.}
   \item{batch_size}{Integer; mini-batch size.}
   \item{max_norm}{Numeric; maximum gradient norm for clipping.}
-  \item{drop_hidden}{Numeric in [0,1]; dropout probability after each hidden layer. When \code{fusion_module} is supplied, applies dropout to the fusion output.}
+  \item{drop_hidden}{Numeric in [0,1]; dropout probability after each non-final layer of the default dense MLP. When \code{fusion_module} is supplied, dropout is applied once to the fusion output.}
   \item{wd_image}{Numeric; weight decay (L2 penalty) for \code{image_module} parameters.}
   \item{wd_tabular}{Numeric; weight decay for \code{tabular_module} parameters.}
   \item{checkpoint_interval}{Integer; number of epochs between saved checkpoints.}
@@ -80,7 +80,7 @@ train_mst_pmdn(
   \item{image_inputs}{Optional array or \code{torch_tensor} of image data (4D) for multimodal models.}
   \item{image_module}{Optional \code{nn_module} for processing \code{image_inputs}.}
   \item{tabular_module}{Optional \code{nn_module} for processing \code{inputs}.}
-  \item{fusion_module}{Optional \code{nn_module} for fusing tabular and image features before the MST-PMDN head.}
+  \item{fusion_module}{Optional \code{nn_module} for fusing tabular and image features. When supplied, it bypasses the default dense MLP; after optional \code{drop_hidden} dropout, its output is passed directly to the MST-PMDN parameter heads. The output width is inferred from \code{output_dim}, \code{out_features}, \code{out_channels}, or \code{out_dim}; the final \code{hidden_dim} value is used as a fallback.}
   \item{min_last_batch_frac}{Numeric in [0,1]; drop the final incomplete training mini-batch only when its size is smaller than \code{ceiling(batch_size * min_last_batch_frac)}. Validation always evaluates every case.}
   \item{device}{Character; torch device to use (e.g., \code{"cpu"} or \code{"cuda"}).}
 }

--- a/tests/testthat/test-network-architecture.R
+++ b/tests/testthat/test-network-architecture.R
@@ -1,0 +1,76 @@
+test_that("default path uses plain linear MLP layers and normalized heads", {
+  model <- define_mst_pmdn(
+    input_dim = 2,
+    output_dim = 1,
+    hidden_dim = c(5, 3),
+    n_mixtures = 2,
+    constraint = "VIINN",
+    drop_hidden = 0.1
+  )
+
+  expect_true(inherits(model$hidden, "nn_sequential"))
+  expect_true(inherits(model$hidden[[1]], "nn_linear"))
+  expect_true(inherits(model$hidden[[5]], "nn_linear"))
+  expect_true(inherits(model$fc_pi, "weight_norm_linear"))
+  expect_true(inherits(model$fc_mu, "weight_norm_linear"))
+})
+
+test_that("custom fusion bypasses the default MLP", {
+  fusion_with_dim <- torch::nn_module(
+    "fusion_with_dim",
+    initialize = function(input_dim = 2, output_dim = 4) {
+      self$output_dim <- output_dim
+      self$projection <- torch::nn_linear(input_dim, output_dim)
+    },
+    forward = function(x) {
+      self$projection(x)
+    }
+  )
+  fusion <- fusion_with_dim()
+
+  model <- define_mst_pmdn(
+    input_dim = 2,
+    output_dim = 1,
+    hidden_dim = integer(0),
+    n_mixtures = 2,
+    constraint = "VIINN",
+    drop_hidden = 0.1,
+    fusion_module = fusion
+  )
+
+  expect_null(model$hidden)
+  expect_true(inherits(model$fusion_dropout, "nn_dropout"))
+  expect_equal(model$final_hidden_dim, 4)
+  pred <- model(torch::torch_randn(c(3, 2)))
+  expect_equal(as.integer(pred$mu$size()), c(3L, 2L, 1L))
+})
+
+test_that("custom fusion can use the final hidden_dim as a width fallback", {
+  fusion_without_dim <- torch::nn_module(
+    "fusion_without_dim",
+    initialize = function(input_dim = 2, output_dim = 5) {
+      self$projection <- torch::nn_linear(input_dim, output_dim)
+    },
+    forward = function(x) {
+      self$projection(x)
+    }
+  )
+  fusion <- fusion_without_dim()
+
+  expect_warning(
+    model <- define_mst_pmdn(
+      input_dim = 2,
+      output_dim = 1,
+      hidden_dim = c(7, 5),
+      n_mixtures = 2,
+      constraint = "VIINN",
+      fusion_module = fusion
+    ),
+    "Using fallback dimension: 5"
+  )
+
+  expect_null(model$hidden)
+  expect_equal(model$final_hidden_dim, 5)
+  pred <- model(torch::torch_randn(c(3, 2)))
+  expect_equal(as.integer(pred$mu$size()), c(3L, 2L, 1L))
+})


### PR DESCRIPTION
## Summary

- correct the README and public manuals to distinguish the default `nn_linear` hidden MLP from the weight-normalized distributional parameter heads
- document that a custom `fusion_module` bypasses the default hidden MLP and receives `drop_hidden` once before the parameter heads
- clarify that `hidden_dim` supplies default-MLP widths and acts only as an output-dimension fallback under custom fusion
- remove the inert `hidden_dim = c(64, 32)` setting from the wave–surge example
- add regression tests for the default MLP, the custom-fusion bypass, and output-dimension fallback

## Motivation

The implementation and documentation had drifted apart. The default hidden MLP currently uses ordinary `nn_linear` layers with batch normalization, activation, and dropout, while only the parameter heads use `weight_norm_linear`. In addition, the wave–surge example supplies a fusion module with `output_dim = 32`, so its `hidden_dim = c(64, 32)` value does not create any layers or affect the architecture.

## Impact

This is a documentation, example, and regression-test correction. The MST-PMDN implementation, saved-model compatibility, and numerical behaviour are unchanged.

## Validation

- verified the branch is five commits ahead of `main` and zero commits behind
- confirmed the diff is limited to the five intended files
- passed `git diff --check`
- confirmed the stale architecture phrases are absent
- package tests and `R CMD check` were not run locally because the execution environment lacks R; the pull-request workflow is expected to provide the R-based validation