### PR TITLE
Bypass symmetric skew work and preserve model dtype

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,7 +12,7 @@ License: GPL (>= 2)
 Encoding: UTF-8
 Depends: R (>= 3.5.0), torch (>= 0.17.0)
 Imports: coro, stats
-Suggests: testthat (>= 3.0.0)
+Suggests: testthat (>= 3.2.0)
 Config/testthat/edition: 3
 LazyData: true
 LazyDataCompression: xz

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: MST.PMDN
 Type: Package
 Title: Deep Multivariate Skew t-Parsimonious Mixture Density Network
-Version: 0.2.0
+Version: 0.2.1
 Authors@R: person(given="Alex J.", family="Cannon",
     email="alex.cannon@ec.gc.ca", role=c("aut", "cre"),
     comment=c(ORCID="0000-0002-8025-3790"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,17 @@
 # MST.PMDN 0.2.1
 
+## Bug fixes
+
+- Sampler latent-normal and Gamma tail-scale draws now follow the model dtype.
+  Float64 models previously drew float32 latents and relied on implicit
+  promotion. Gamma draws are now made in one vectorized R call.
+- `predict_mst_pmdn()` now coerces non-tensor tabular and image inputs to the
+  model dtype instead of always using float32. Supplied tensors retain their
+  dtype, and a mismatch with the model now errors at the call boundary rather
+  than inside the network, with an explicit conversion remedy. Parameterless
+  modules retain the previous float32 coercion for non-tensor inputs and
+  preserve the dtype of supplied tensors.
+
 ## Performance
 
 - Models with the `"N"` skewness constraint now bypass the skew-factor block

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,16 @@
+# MST.PMDN 0.2.1
+
+## Performance
+
+- Models with the `"N"` skewness constraint now bypass the skew-factor block
+  in `loss_mst_pmdn()` and the skew-normal construction in
+  `sample_mst_pmdn()`. Loss values and trainable-parameter gradients are
+  unchanged. Inactive skewness and degrees-of-freedom penalties no longer
+  construct reduction graphs.
+- Symmetric sampling consumes a different RNG sequence because the redundant
+  scalar-normal draw is no longer made. Fixed seeds remain reproducible within
+  this version but do not reproduce sample streams from earlier versions.
+
 # MST.PMDN 0.2.0
 
 - Corrected one-based mixture-component sampling and the multivariate

--- a/R/MST-PMDN.R
+++ b/R/MST-PMDN.R
@@ -923,6 +923,7 @@ define_mst_pmdn <- function(
         scale_chol = scale_chol,   # [B, M, d, d]
         nu    = nu,                # [B, M]
         alpha = alpha,             # [B, M, d]
+        skew_none = self$skew_none,
         # Volume/Shape/Orientation breakdown
         L     = L_val,   # [B, M, 1, 1]
         A     = A_diag,  # [B, M, d]
@@ -936,10 +937,66 @@ define_mst_pmdn <- function(
 # PMDN skew t-distribution loss function
 # --------------------------------------
 
+.validate_skew_none <- function(output, name = "output") {
+  skew_none <- output$skew_none
+  if (is.null(skew_none)) {
+    return(FALSE)
+  }
+  if (!is.logical(skew_none) ||
+      length(skew_none) != 1L ||
+      is.na(skew_none)) {
+    stop(
+      sprintf("%s$skew_none must be a single non-missing logical value.", name),
+      call. = FALSE
+    )
+  }
+  skew_none
+}
+
+.require_alpha <- function(output, name = "output") {
+  if (is.null(output$alpha)) {
+    stop(sprintf("%s$alpha is required.", name), call. = FALSE)
+  }
+  invisible(output$alpha)
+}
+
+.validate_penalty_weight <- function(value, name) {
+  if (!is.numeric(value) ||
+      length(value) != 1L ||
+      !is.finite(value) ||
+      value < 0) {
+    stop(
+      sprintf(
+        "%s must be a single finite non-negative numeric value.",
+        name
+      ),
+      call. = FALSE
+    )
+  }
+  value
+}
+
+.log_skew_factor_mst <- function(alpha, v, nu_safe, maha, normal, d) {
+  cterm <- torch_sqrt((nu_safe + d) / (nu_safe + maha))$clamp(max = 1e6)
+  cterm <- torch_where(normal, torch_ones_like(cterm), cterm)$unsqueeze(-1)
+  alpha_dot_w <- (alpha * (cterm * v))$sum(dim = 3)
+  # R numeric scalars are weak in torch arithmetic: log(2) follows the
+  # tensor dtype and device without allocating a tensor constant per call.
+  log(2) + torch_where(
+    normal,
+    .log_normal_cdf(alpha_dot_w),
+    log_pt(alpha_dot_w, nu_safe + d)
+  )
+}
+
 loss_mst_pmdn <- function(output, target,
                           lambda_alpha = 0, lambda_nu_inv = 0) {
   # Output must have: pi, mu, scale (Cholesky L), nu, alpha
   # target shape: [B, d]
+  lambda_alpha <- .validate_penalty_weight(lambda_alpha, "lambda_alpha")
+  lambda_nu_inv <- .validate_penalty_weight(lambda_nu_inv, "lambda_nu_inv")
+  .require_alpha(output)
+  skew_none <- .validate_skew_none(output)
   mix_prob   <- output$pi         # [B, M]
   mu         <- output$mu         # [B, M, d]
   scale_chol <- output$scale_chol # [B, M, d, d]
@@ -980,26 +1037,14 @@ loss_mst_pmdn <- function(output, target,
                     0.5 * log_det_Sigma - 0.5 * maha
   log_pdf <- torch_where(normal, log_pdf_normal, log_pdf_t)
 
-  # Skewness factor calculation
-  # Clamp large values, [B, M, 1]. The limit is one for normal components.
-  cterm <- torch_sqrt((nu_safe + d) / (nu_safe + maha))$clamp(max = 1e6)
-  cterm <- torch_where(normal, torch_ones_like(cterm), cterm)$unsqueeze(-1)
-  w <- cterm * v # [B, M, d]
-  # alpha^T w
-  alpha_dot_w <- (alpha * w)$sum(dim = 3) # [B, M]
-  # The finite-t skew factor uses T_1; its exact normal limit uses Phi.
-  log_skew_cdf <- torch_where(
-    normal,
-    .log_normal_cdf(alpha_dot_w),
-    log_pt(alpha_dot_w, nu_safe + d)
-  )
-  log_skew_factor <- torch_log(torch_tensor(
-    2.0,
-    dtype = mix_prob$dtype,
-    device = dev
-  )) +
-                     log_skew_cdf
-  log_component <- log_pdf + log_skew_factor # [B, M]
+  if (skew_none) {
+    log_component <- log_pdf
+  } else {
+    log_component <- log_pdf + .log_skew_factor_mst(
+      alpha = alpha, v = v, nu_safe = nu_safe,
+      maha = maha, normal = normal, d = d
+    )
+  }
   # Mixture weighting and log-sum-exp for total log-likelihood
   # log P(y|x) = log sum_k [ pi_k * SkewT(y | mu_k, Sigma_k, alpha_k, nu_k) ]
   #            = logsumexp_k [ log(pi_k) + log(SkewT(...)) ]
@@ -1007,25 +1052,29 @@ loss_mst_pmdn <- function(output, target,
                         log_component # [B, M]
   # Negative log-likelihood (average over batch)
   loss <- -torch_logsumexp(weighted_log_probs, dim = 2)$mean()
-  # L2 penalty on final alpha values
-  lambda_alpha_tensor <- torch_tensor(
-    lambda_alpha,
-    dtype = loss$dtype,
-    device = dev
-  )
-  loss <- loss + lambda_alpha_tensor * alpha$pow(2)$mean()
-  # (1/nu)^2 penalty on degrees of freedom
-  nu_inv_sq <- torch_where(
-    normal,
-    torch_zeros_like(nu_safe),
-    nu_safe$pow(-2)
-  )
-  lambda_nu_inv_tensor <- torch_tensor(
-    lambda_nu_inv,
-    dtype = loss$dtype,
-    device = dev
-  )
-  loss <- loss + lambda_nu_inv_tensor * nu_inv_sq$mean()
+  # Construct penalty graphs only when their weights are active. Under the
+  # structural symmetric constraint the alpha penalty is identically zero.
+  if (lambda_alpha > 0 && !skew_none) {
+    lambda_alpha_tensor <- torch_tensor(
+      lambda_alpha,
+      dtype = loss$dtype,
+      device = dev
+    )
+    loss <- loss + lambda_alpha_tensor * alpha$pow(2)$mean()
+  }
+  if (lambda_nu_inv > 0) {
+    nu_inv_sq <- torch_where(
+      normal,
+      torch_zeros_like(nu_safe),
+      nu_safe$pow(-2)
+    )
+    lambda_nu_inv_tensor <- torch_tensor(
+      lambda_nu_inv,
+      dtype = loss$dtype,
+      device = dev
+    )
+    loss <- loss + lambda_nu_inv_tensor * nu_inv_sq$mean()
+  }
   loss
 }
 
@@ -1036,12 +1085,16 @@ loss_mst_pmdn <- function(output, target,
 
 sample_mst_pmdn <- function(mdn_output, num_samples = 1, device = "cpu") {
   num_samples <- validate_num_samples(num_samples)
+  .require_alpha(mdn_output, "mdn_output")
+  skew_none <- .validate_skew_none(mdn_output, "mdn_output")
   # gather parameters
   pi     <- mdn_output$pi          $to(device = device)
   mu     <- mdn_output$mu          $to(device = device)
   L_all  <- mdn_output$scale_chol  $to(device = device)
   nu_all <- mdn_output$nu          $to(device = device)
-  alpha_all <- mdn_output$alpha    $to(device = device)
+  if (!skew_none) {
+    alpha_all <- mdn_output$alpha$to(device = device)
+  }
   B <- pi$size(1)
   # M <- pi$size(2)
   d <- mu$size(3)
@@ -1054,7 +1107,6 @@ sample_mst_pmdn <- function(mdn_output, num_samples = 1, device = "cpu") {
   mu_s    <- mu       $gather(2, idx_d)
   L_s     <- L_all    $gather(2, idx_dd)
   nu_s    <- nu_all   $gather(2, idx)
-  alpha_s <- alpha_all$gather(2, idx_d)
   # Gamma scaling for Student-t tails. Exact normal components use W = 1;
   # a finite placeholder prevents Inf from entering the unused Gamma branch.
   normal_s <- nu_s == Inf
@@ -1066,25 +1118,30 @@ sample_mst_pmdn <- function(mdn_output, num_samples = 1, device = "cpu") {
     W_t <- torch_sqrt(nu_sample / chi2$clamp(min = 1e-12))
     W <- torch_where(normal_s, torch_ones_like(W_t), W_t)$unsqueeze(-1)
   }
-  # skew direction (identity-covariance, Sigma = I convention)
-  alpha_norm_sq <- alpha_s$pow(2)$sum(dim = -1, keepdim = TRUE)
-  delta <- alpha_s / torch_sqrt(1 + alpha_norm_sq)
-  delta_norm_sq <- delta$pow(2)$sum(dim = -1, keepdim = TRUE)
-  # standard normals
-  z0 <- torch_randn(c(B, num_samples, 1), device = device)
-  z1 <- torch_randn(c(B, num_samples, d), device = device)
-  # Skew-normal core.  The residual requires the symmetric matrix square root
-  # of I - delta delta^T.  Apply its rank-one form without materializing a
-  # [B, S, d, d] tensor:
-  # (I - delta delta^T)^(1/2) z =
-  # z - delta (delta^T z) / (1 + sqrt(1 - ||delta||^2)).
-  sqrt_one_minus_delta_sq <- torch_sqrt(
-    (1 - delta_norm_sq)$clamp(min = 1e-12)
-  )
-  delta_dot_z1 <- (delta * z1)$sum(dim = -1, keepdim = TRUE)
-  residual <- z1 - delta * delta_dot_z1 /
-    (1 + sqrt_one_minus_delta_sq)
-  X <- delta * torch_abs(z0) + residual
+  if (skew_none) {
+    X <- torch_randn(c(B, num_samples, d), device = device)
+  } else {
+    alpha_s <- alpha_all$gather(2, idx_d)
+    # skew direction (identity-covariance, Sigma = I convention)
+    alpha_norm_sq <- alpha_s$pow(2)$sum(dim = -1, keepdim = TRUE)
+    delta <- alpha_s / torch_sqrt(1 + alpha_norm_sq)
+    delta_norm_sq <- delta$pow(2)$sum(dim = -1, keepdim = TRUE)
+    # standard normals
+    z0 <- torch_randn(c(B, num_samples, 1), device = device)
+    z1 <- torch_randn(c(B, num_samples, d), device = device)
+    # Skew-normal core. The residual requires the symmetric matrix square root
+    # of I - delta delta^T. Apply its rank-one form without materializing a
+    # [B, S, d, d] tensor:
+    # (I - delta delta^T)^(1/2) z =
+    # z - delta (delta^T z) / (1 + sqrt(1 - ||delta||^2)).
+    sqrt_one_minus_delta_sq <- torch_sqrt(
+      (1 - delta_norm_sq)$clamp(min = 1e-12)
+    )
+    delta_dot_z1 <- (delta * z1)$sum(dim = -1, keepdim = TRUE)
+    residual <- z1 - delta * delta_dot_z1 /
+      (1 + sqrt_one_minus_delta_sq)
+    X <- delta * torch_abs(z0) + residual
+  }
   # affine map to response space  Y
   Y <- mu_s + W * (torch_matmul(L_s, X$unsqueeze(-1))$squeeze(-1))
   # return both samples and component IDs

--- a/R/MST-PMDN.R
+++ b/R/MST-PMDN.R
@@ -21,15 +21,20 @@ sample_gamma <- function(shape, scale = 1, device = "cpu") {
     shape <- shape$to(device = device)
   }
   if (!inherits(scale, "torch_tensor")) {
-    scale <- torch_tensor(scale, device = device, dtype = torch_float())
+    scale <- torch_tensor(scale, device = device, dtype = shape$dtype)
   } else {
     scale <- scale$to(device = device)
   }
   shape_cpu <- as.numeric(shape$to(device = "cpu"))
   scale_cpu <- as.numeric(scale$to(device = "cpu"))
-  # Sample using rgamma(shape, scale) where rate = 1/scale
-  samples_r <- mapply(rgamma, n = 1, shape = shape_cpu, rate = 1 / scale_cpu)
-  out <- torch_tensor(samples_r, dtype = torch_float())$
+  # Sample using rgamma(shape, scale) where rate = 1/scale. A single vectorized
+  # call avoids one R-level RNG call per latent value.
+  samples_r <- rgamma(
+    length(shape_cpu),
+    shape = shape_cpu,
+    rate = 1 / scale_cpu
+  )
+  out <- torch_tensor(samples_r, dtype = shape$dtype)$
     reshape(shape$size())$
     to(device = device)
   return(out)
@@ -1119,7 +1124,11 @@ sample_mst_pmdn <- function(mdn_output, num_samples = 1, device = "cpu") {
     W <- torch_where(normal_s, torch_ones_like(W_t), W_t)$unsqueeze(-1)
   }
   if (skew_none) {
-    X <- torch_randn(c(B, num_samples, d), device = device)
+    X <- torch_randn(
+      c(B, num_samples, d),
+      dtype = mu$dtype,
+      device = device
+    )
   } else {
     alpha_s <- alpha_all$gather(2, idx_d)
     # skew direction (identity-covariance, Sigma = I convention)
@@ -1127,8 +1136,16 @@ sample_mst_pmdn <- function(mdn_output, num_samples = 1, device = "cpu") {
     delta <- alpha_s / torch_sqrt(1 + alpha_norm_sq)
     delta_norm_sq <- delta$pow(2)$sum(dim = -1, keepdim = TRUE)
     # standard normals
-    z0 <- torch_randn(c(B, num_samples, 1), device = device)
-    z1 <- torch_randn(c(B, num_samples, d), device = device)
+    z0 <- torch_randn(
+      c(B, num_samples, 1),
+      dtype = mu$dtype,
+      device = device
+    )
+    z1 <- torch_randn(
+      c(B, num_samples, d),
+      dtype = mu$dtype,
+      device = device
+    )
     # Skew-normal core. The residual requires the symmetric matrix square root
     # of I - delta delta^T. Apply its rank-one form without materializing a
     # [B, S, d, d] tensor:
@@ -1962,21 +1979,75 @@ train_mst_pmdn <- function(inputs,
 # PMDN inference function with optional image inputs
 # --------------------------------------------------
 
+.model_dtype_info <- function(model_parameters) {
+  if (length(model_parameters) == 0L) {
+    return(list(dtype = NULL, parameter_name = NULL))
+  }
+  parameter_names <- names(model_parameters)
+  if (is.null(parameter_names) || length(parameter_names) < 1L) {
+    model_parameter_name <- "<unnamed>"
+  } else {
+    model_parameter_name <- parameter_names[[1]]
+    if (is.na(model_parameter_name) || !nzchar(model_parameter_name)) {
+      model_parameter_name <- "<unnamed>"
+    }
+  }
+  list(
+    dtype = model_parameters[[1]]$dtype,
+    parameter_name = model_parameter_name
+  )
+}
+
 predict_mst_pmdn <- function(model, new_inputs, image_inputs = NULL,
                              device = "cpu") {
   model$eval()
+  model_dtype_info <- .model_dtype_info(model$parameters)
+  model_parameter_name <- model_dtype_info$parameter_name
+  model_dtype <- model_dtype_info$dtype
   if (!inherits(new_inputs, "torch_tensor")) {
+    input_dtype <- if (is.null(model_dtype)) torch_float() else model_dtype
     new_inputs <- torch_tensor(new_inputs, device = device,
-                               dtype = torch_float())
+                               dtype = input_dtype)
   } else {
     new_inputs <- new_inputs$to(device = device)
   }
+  if (!is.null(model_dtype) && new_inputs$dtype != model_dtype) {
+    stop(
+      sprintf(
+        paste0(
+          "new_inputs has dtype %s but model parameter %s expects %s. ",
+          "Convert it explicitly with ",
+          "new_inputs$to(dtype = model$parameters[[1]]$dtype)."
+        ),
+        format(new_inputs$dtype),
+        model_parameter_name,
+        format(model_dtype)
+      ),
+      call. = FALSE
+    )
+  }
   if (!is.null(image_inputs)) {
     if (!inherits(image_inputs, "torch_tensor")) {
+      image_dtype <- if (is.null(model_dtype)) torch_float() else model_dtype
       image_inputs <- torch_tensor(image_inputs, device = device,
-                                   dtype = torch_float())
+                                   dtype = image_dtype)
     } else {
       image_inputs <- image_inputs$to(device = device)
+    }
+    if (!is.null(model_dtype) && image_inputs$dtype != model_dtype) {
+      stop(
+        sprintf(
+          paste0(
+            "image_inputs has dtype %s but model parameter %s expects %s. ",
+            "Convert it explicitly with ",
+            "image_inputs$to(dtype = model$parameters[[1]]$dtype)."
+          ),
+          format(image_inputs$dtype),
+          model_parameter_name,
+          format(model_dtype)
+        ),
+        call. = FALSE
+      )
     }
     with_no_grad({
       model(new_inputs, image_inputs)

--- a/man/cdf_marginal_mst_pmdn.Rd
+++ b/man/cdf_marginal_mst_pmdn.Rd
@@ -13,7 +13,7 @@ cdf_marginal_mst_pmdn(
 )
 }
 \arguments{
-  \item{mdn_output}{A \code{list} as returned by \code{\link{predict_mst_pmdn}} containing mixture parameters.}
+  \item{mdn_output}{A \code{list} as returned by \code{\link{predict_mst_pmdn}} containing mixture parameters. The optional \code{skew_none} field is passed through when Monte Carlo draws are generated; if absent, sampling uses the general skew path. In a hand-built list, \code{skew_none = TRUE} is valid only when \code{alpha} is structurally zero.}
   \item{y}{Numeric vector of response values at which to evaluate the marginal CDF.}
   \item{var_index}{Integer; indices of the response dimensions to evaluate. Defaults to all output dimensions.}
   \item{num_samples}{Integer; number of Monte Carlo draws used to approximate the marginal CDF.}

--- a/man/loss_mst_pmdn.Rd
+++ b/man/loss_mst_pmdn.Rd
@@ -6,14 +6,19 @@ loss_mst_pmdn(output, target, lambda_alpha = 0, lambda_nu_inv = 0)
 }
 \arguments{
   \item{output}{A list as returned by a forward pass of an \code{mst_pmdn_model}, containing at least the following named \code{\link[torch]{torch_tensor}} elements:
-    \code{pi}, \code{mu}, \code{scale_chol}, \code{nu}, and \code{alpha}.}
+    \code{pi}, \code{mu}, \code{scale_chol}, \code{nu}, and \code{alpha}.
+    The optional single logical field \code{skew_none = TRUE} selects the
+    symmetric fast path. If the field is absent, the general skew factor is
+    evaluated. For a hand-built list, setting \code{skew_none = TRUE} requires
+    \code{alpha} to be structurally zero; the caller is responsible for
+    maintaining this invariant.}
   \item{target}{A \code{\link[torch]{torch_tensor}} or numeric matrix of true responses, with shape \code{[batch_size, d]}.}
-  \item{lambda_alpha}{Numeric scalar; L2 penalty weight applied to the final skewness parameters \code{alpha}.}
-  \item{lambda_nu_inv}{Numeric scalar; penalty weight applied to \code{(1/nu)^2}. Exact normal components contribute zero.}
+  \item{lambda_alpha}{Single finite non-negative numeric value; L2 penalty weight applied to the final skewness parameters \code{alpha}.}
+  \item{lambda_nu_inv}{Single finite non-negative numeric value; penalty weight applied to \code{(1/nu)^2}. Exact normal components contribute zero.}
 }
 \description{
 Computes the average negative log-likelihood under a mixture of multivariate skew t and exact Gaussian/skew-normal components for a batch of examples.
-The function extracts mixture weights, component locations, Cholesky scale factors, degrees of freedom, and skewness parameters from \code{output}, then evaluates the MST-PMDN log-density at \code{target}, finally averaging (and negating) to produce the loss. Finite-\code{nu} components use a cancellation-resistant multivariate t normalizing constant and Hill's Student t approximation through a direct, stable log-CDF. Components with \code{nu = Inf} use the exact Gaussian kernel and normal log-CDF.
+The function extracts mixture weights, component locations, Cholesky scale factors, degrees of freedom, and skewness parameters from \code{output}, then evaluates the MST-PMDN log-density at \code{target}, finally averaging (and negating) to produce the loss. Finite-\code{nu} components use a cancellation-resistant multivariate t normalizing constant and Hill's Student t approximation through a direct, stable log-CDF. Components with \code{nu = Inf} use the exact Gaussian kernel and normal log-CDF. Outputs with \code{skew_none = TRUE} bypass the skew-factor calculation. Model-generated outputs satisfy the required invariant that \code{alpha} is structurally zero; hand-built outputs must satisfy it explicitly.
 }
 \value{
 A single-element \code{\link[torch]{torch_tensor}} containing the batch-averaged negative log-likelihood.

--- a/man/predict_mst_pmdn.Rd
+++ b/man/predict_mst_pmdn.Rd
@@ -2,17 +2,18 @@
 \alias{predict_mst_pmdn}
 \title{Generate predictions from a trained MST-PMDN model}
 \description{
-Wraps a trained \code{mst_pmdn_model} in evaluation mode, converts inputs to 
-\code{\link[torch]{torch_tensor}} if necessary, and runs a forward pass without 
-tracking gradients to produce mixture-distribution parameters.
+Wraps a trained \code{mst_pmdn_model} in evaluation mode, converts inputs to
+\code{\link[torch]{torch_tensor}} if necessary using the model's floating-point
+dtype, and runs a forward pass without tracking gradients to produce
+mixture-distribution parameters.
 }
 \usage{
 predict_mst_pmdn(model, new_inputs, image_inputs = NULL, device = "cpu")
 }
 \arguments{
   \item{model}{An \code{mst_pmdn_model} object (a \pkg{torch} module), typically returned by \code{\link{train_mst_pmdn}}.}
-  \item{new_inputs}{A numeric matrix or \code{\link[torch]{torch_tensor}} of tabular predictors.  If not already a tensor, it is converted via \code{\link[torch]{torch_tensor}} on the specified \code{device}.}
-  \item{image_inputs}{Optional 4D array or \code{torch_tensor} of image data for models with an \code{image_module}.  If provided, must match the module’s expected shape; otherwise set to \code{NULL}.}
+  \item{new_inputs}{A numeric matrix or \code{\link[torch]{torch_tensor}} of tabular predictors. If not already a tensor, it is converted on the specified \code{device} using the dtype of the model's first parameter, or float32 when the model has no parameters. A supplied tensor retains its dtype and must match the model dtype when one can be inferred.}
+  \item{image_inputs}{Optional 4D array or \code{torch_tensor} of image data for models with an \code{image_module}. Non-tensor input is converted to the model dtype, or float32 when the model has no parameters. A supplied tensor retains its dtype and must match the model dtype when one can be inferred. If provided, the input must match the module's expected shape; otherwise set to \code{NULL}.}
   \item{device}{Character; the torch device to use (e.g. \code{"cpu"} or \code{"cuda"}).  Defaults to \code{"cpu"}.}
 }
 \value{
@@ -28,4 +29,13 @@ A named \code{list} containing the output of the model’s forward pass:
   omit this field; consumers then evaluate the general skew path.}
   \item{\code{L}, \code{A}, \code{D}}{Volume, shape, and orientation decomposition tensors for each component.}
 }
+}
+\details{
+The model dtype is inferred from its first parameter. For a model with no
+parameters, non-tensor inputs retain the legacy float32 conversion and supplied
+tensors retain their dtype; no model-dtype validation is possible. For a
+parameterized model, tensor inputs with a different dtype produce an error
+before the model's first matrix multiplication. The diagnostic names the
+parameter used for inference (or reports \code{<unnamed>}) and shows how to
+convert the input explicitly with \code{$to(dtype = ...)}.
 }

--- a/man/predict_mst_pmdn.Rd
+++ b/man/predict_mst_pmdn.Rd
@@ -23,6 +23,9 @@ A named \code{list} containing the output of the model’s forward pass:
   \item{\code{scale_chol}}{Cholesky scale factors tensor of shape \code{[batch_size, M, d, d]}.}
   \item{\code{nu}}{Degrees-of-freedom tensor of shape \code{[batch_size, M]}; \code{Inf} marks an exact Gaussian/skew-normal component.}
   \item{\code{alpha}}{Skewness parameters tensor of shape \code{[batch_size, M, d]}.}
+  \item{\code{skew_none}}{A single logical value indicating whether the model
+  has the \code{"N"} skewness constraint. Older or hand-built output lists may
+  omit this field; consumers then evaluate the general skew path.}
   \item{\code{L}, \code{A}, \code{D}}{Volume, shape, and orientation decomposition tensors for each component.}
 }
 }

--- a/man/quantile_marginal_mst_pmdn.Rd
+++ b/man/quantile_marginal_mst_pmdn.Rd
@@ -13,7 +13,7 @@ quantile_marginal_mst_pmdn(
 )
 }
 \arguments{
-  \item{mdn_output}{A \code{list} as returned by \code{\link{predict_mst_pmdn}} or a forward pass of an \code{mst_pmdn_model}, containing at minimum the following named \code{\link[torch]{torch_tensor}} elements: \code{pi}, \code{mu}, \code{scale_chol}, \code{nu}, and \code{alpha}.}
+  \item{mdn_output}{A \code{list} as returned by \code{\link{predict_mst_pmdn}} or a forward pass of an \code{mst_pmdn_model}, containing at minimum the following named \code{\link[torch]{torch_tensor}} elements: \code{pi}, \code{mu}, \code{scale_chol}, \code{nu}, and \code{alpha}. The optional \code{skew_none} field is passed through when Monte Carlo draws are generated; if absent, sampling uses the general skew path. In a hand-built list, \code{skew_none = TRUE} is valid only when \code{alpha} is structurally zero.}
   \item{probs}{Numeric matrix or \pkg{torch} tensor with shape \eqn{B \times V} containing probabilities in \eqn{[0, 1]} for each batch item and output dimension.}
   \item{var_index}{Integer vector of output dimension indices to summarize. Defaults to all output dimensions.}
   \item{num_samples}{Integer; number of Monte Carlo draws per input case. Defaults to \code{1000}.}

--- a/man/sample_mst_pmdn.Rd
+++ b/man/sample_mst_pmdn.Rd
@@ -5,13 +5,13 @@
 sample_mst_pmdn(mdn_output, num_samples = 1, device = "cpu")
 }
 \arguments{
-  \item{mdn_output}{A \code{list} as returned by \code{\link{predict_mst_pmdn}} or a forward pass of an \code{mst_pmdn_model}, containing at minimum the following named \code{\link[torch]{torch_tensor}} elements: \code{pi}, \code{mu}, \code{scale_chol}, \code{nu}, and \code{alpha}.}
+  \item{mdn_output}{A \code{list} as returned by \code{\link{predict_mst_pmdn}} or a forward pass of an \code{mst_pmdn_model}, containing at minimum the following named \code{\link[torch]{torch_tensor}} elements: \code{pi}, \code{mu}, \code{scale_chol}, \code{nu}, and \code{alpha}. The optional single logical field \code{skew_none = TRUE} selects direct symmetric latent sampling. If the field is absent, the general skew-normal construction is used. For a hand-built list, setting \code{skew_none = TRUE} requires \code{alpha} to be structurally zero; the caller is responsible for maintaining this invariant.}
   \item{num_samples}{Integer; number of random draws to generate per input case. Defaults to \code{1}.}
   \item{device}{Character; a \pkg{torch} device on which to perform sampling (e.g. \code{"cpu"} or \code{"cuda"}). Defaults to \code{"cpu"}.}
 }
 \description{
 Performs mixture sampling from the multivariate skew t and skew-normal predictive distribution encapsulated in \code{mdn_output}.
-For each of the \code{num_samples} draws, a mixture component is sampled according to the mixture weights \code{pi}. Finite-\code{nu} components use the Gaussian plus Gamma skew-\emph{t} construction; components with \code{nu = Inf} use its exact skew-normal limit with no random tail scale.
+For each of the \code{num_samples} draws, a mixture component is sampled according to the mixture weights \code{pi}. Finite-\code{nu} components use the Gaussian plus Gamma skew-\emph{t} construction; components with \code{nu = Inf} use its exact skew-normal limit with no random tail scale. Structurally symmetric outputs draw the Gaussian latent directly and omit the redundant skew-normal latent and rank-one correction.
 The output tensors are permuted so that the first dimension indexes the draw number.  
 }
 \value{

--- a/man/sample_mst_pmdn.Rd
+++ b/man/sample_mst_pmdn.Rd
@@ -17,7 +17,7 @@ The output tensors are permuted so that the first dimension indexes the draw num
 \value{
 A \code{list} with components:
 \describe{
-  \item{\code{samples}}{A \code{\link[torch]{torch_tensor}} of shape \code{c(num_samples, batch_size, d)}, giving the sampled responses.}
+  \item{\code{samples}}{A \code{\link[torch]{torch_tensor}} of shape \code{c(num_samples, batch_size, d)}, giving the sampled responses with the same floating-point dtype as \code{mdn_output$mu}.}
   \item{\code{components}}{A \code{\link[torch]{torch_tensor}} of shape \code{c(num_samples, batch_size)}, containing the index (1–\code{M}) of the mixture component used for each draw.}
 }
 }

--- a/man/sample_mst_pmdn_df.Rd
+++ b/man/sample_mst_pmdn_df.Rd
@@ -7,7 +7,7 @@ sample_mst_pmdn_df(mdn_output, num_samples = 1, device = "cpu")
 }
 
 \arguments{
-  \item{mdn_output}{A \code{list} as returned by \code{\link{predict_mst_pmdn}} or a forward pass of an \code{mst_pmdn_model}, containing at minimum the following named \code{\link[torch]{torch_tensor}} elements: \code{pi}, \code{mu}, \code{scale_chol}, \code{nu}, and \code{alpha}.}
+  \item{mdn_output}{A \code{list} as returned by \code{\link{predict_mst_pmdn}} or a forward pass of an \code{mst_pmdn_model}, containing at minimum the following named \code{\link[torch]{torch_tensor}} elements: \code{pi}, \code{mu}, \code{scale_chol}, \code{nu}, and \code{alpha}. The optional \code{skew_none} field is passed to \code{\link{sample_mst_pmdn}}; if absent, the general skew path is used. In a hand-built list, \code{skew_none = TRUE} is valid only when \code{alpha} is structurally zero.}
   \item{num_samples}{Integer; number of random draws to generate per input case. Defaults to \code{1}.}
   \item{device}{Character; the torch device on which sampling is performed (e.g.\ \code{"cpu"} or \code{"cuda"}). Defaults to \code{"cpu"}.}
 }

--- a/tests/testthat/helper-prediction.R
+++ b/tests/testthat/helper-prediction.R
@@ -1,5 +1,6 @@
-make_mdn_output <- function(pi, mu, scale_chol, nu, alpha) {
-  list(
+make_mdn_output <- function(pi, mu, scale_chol, nu, alpha,
+                            skew_none = NULL) {
+  output <- list(
     pi = torch::torch_tensor(pi, dtype = torch::torch_float()),
     mu = torch::torch_tensor(mu, dtype = torch::torch_float()),
     scale_chol = torch::torch_tensor(
@@ -8,6 +9,10 @@ make_mdn_output <- function(pi, mu, scale_chol, nu, alpha) {
     nu = torch::torch_tensor(nu, dtype = torch::torch_float()),
     alpha = torch::torch_tensor(alpha, dtype = torch::torch_float())
   )
+  if (!is.null(skew_none)) {
+    output$skew_none <- skew_none
+  }
+  output
 }
 
 expect_state_dict_equal <- function(x, y, tolerance = 1e-6) {

--- a/tests/testthat/test-normal-limit.R
+++ b/tests/testthat/test-normal-limit.R
@@ -14,6 +14,27 @@ test_that("normal constraints and fixed Inf use the exact limit", {
   )
   normal_pred <- normal_model(x)
   expect_true(all(is.infinite(normal_test_values(normal_pred$nu))))
+  expect_identical(normal_pred$skew_none, TRUE)
+  expect_true(all(normal_test_values(normal_pred$alpha) == 0))
+  expect_null(normal_model$fc_alpha)
+  expect_null(normal_model$alpha_param)
+
+  shared_skew_model <- define_mst_pmdn(
+    input_dim = 2,
+    output_dim = 1,
+    hidden_dim = c(3),
+    n_mixtures = 2,
+    constraint = "VIINE"
+  )
+  varying_skew_model <- define_mst_pmdn(
+    input_dim = 2,
+    output_dim = 1,
+    hidden_dim = c(3),
+    n_mixtures = 2,
+    constraint = "VIINV"
+  )
+  expect_identical(shared_skew_model(x)$skew_none, FALSE)
+  expect_identical(varying_skew_model(x)$skew_none, FALSE)
 
   mixed_model <- define_mst_pmdn(
     input_dim = 2,
@@ -27,6 +48,31 @@ test_that("normal constraints and fixed Inf use the exact limit", {
   mixed_nu <- torch::as_array(mixed_model(x)$nu)
   expect_true(all(is.infinite(mixed_nu[, 1])))
   expect_equal(mixed_nu[, 2], rep(26.5, 4), tolerance = 1e-6)
+})
+
+test_that("constant skewness remains on the general skew path", {
+  torch::torch_manual_seed(419)
+  x <- torch::torch_zeros(c(4, 2))
+  model <- define_mst_pmdn(
+    input_dim = 2,
+    output_dim = 2,
+    hidden_dim = c(3),
+    n_mixtures = 2,
+    constraint = "VIINE",
+    constant_attr = "s"
+  )
+  pred <- model(x)
+  alpha <- torch::as_array(pred$alpha)
+
+  expect_identical(pred$skew_none, FALSE)
+  expect_null(model$fc_alpha)
+  expect_false(is.null(model$alpha_param))
+  expect_gt(max(abs(alpha)), 0)
+  for (b in seq_len(dim(alpha)[1])) {
+    for (m in seq_len(dim(alpha)[2])) {
+      expect_equal(alpha[b, m, ], alpha[1, 1, ], tolerance = 0)
+    }
+  }
 })
 
 test_that("normal and mixed fixed nu paths preserve float64 dtype", {
@@ -229,7 +275,8 @@ test_that("normal sampling omits Student-t scale variability", {
     mu = array(0, c(1, 1, 1)),
     scale_chol = array(1, c(1, 1, 1, 1)),
     nu = matrix(Inf, 1, 1),
-    alpha = array(0, c(1, 1, 1))
+    alpha = array(0, c(1, 1, 1)),
+    skew_none = TRUE
   )
 
   set.seed(17)

--- a/tests/testthat/test-sampling.R
+++ b/tests/testthat/test-sampling.R
@@ -65,3 +65,111 @@ test_that("multivariate skew-t samples match analytic moments", {
   expect_equal(colMeans(draws), expected_mean, tolerance = 0.035)
   expect_equal(stats::cov(draws), expected_cov, tolerance = 0.05)
 })
+
+test_that("symmetric finite-t sampling has the analytic variance", {
+  skip_on_cran()
+  nu <- 8
+  pred <- make_mdn_output(
+    pi = matrix(1, 1, 1),
+    mu = array(0, c(1, 1, 1)),
+    scale_chol = array(1, c(1, 1, 1, 1)),
+    nu = matrix(nu, 1, 1),
+    alpha = array(0, c(1, 1, 1)),
+    skew_none = TRUE
+  )
+
+  set.seed(61)
+  torch::torch_manual_seed(61)
+  draws <- as.numeric(torch::as_array(
+    sample_mst_pmdn(pred, num_samples = 40000)$samples
+  ))
+
+  expect_equal(mean(draws), 0, tolerance = 0.025)
+  expect_equal(stats::var(draws), nu / (nu - 2), tolerance = 0.06)
+})
+
+test_that("symmetric Gaussian sampling respects a nonidentity Cholesky factor", {
+  skip_on_cran()
+  L <- matrix(c(1, 0, 0.4, 1.2), nrow = 2, byrow = TRUE)
+  pred <- make_mdn_output(
+    pi = matrix(1, 1, 1),
+    mu = array(0, c(1, 1, 2)),
+    scale_chol = array(L, c(1, 1, 2, 2)),
+    nu = matrix(Inf, 1, 1),
+    alpha = array(0, c(1, 1, 2)),
+    skew_none = TRUE
+  )
+
+  set.seed(62)
+  torch::torch_manual_seed(62)
+  draws <- torch::as_array(
+    sample_mst_pmdn(pred, num_samples = 40000)$samples
+  )[, 1, ]
+
+  expect_equal(colMeans(draws), c(0, 0), tolerance = 0.025)
+  expect_equal(stats::cov(draws), L %*% t(L), tolerance = 0.04)
+})
+
+test_that("symmetric sampling preserves dimensions and mixture frequencies", {
+  skip_on_cran()
+  probabilities <- c(0.2, 0.5, 0.3)
+  B <- 2L
+  M <- length(probabilities)
+  d <- 3L
+  S <- 40000L
+  scale_chol <- array(0, c(B, M, d, d))
+  for (b in seq_len(B)) {
+    for (m in seq_len(M)) {
+      scale_chol[b, m, , ] <- diag(d)
+    }
+  }
+  pred <- make_mdn_output(
+    pi = matrix(rep(probabilities, B), nrow = B, byrow = TRUE),
+    mu = array(0, c(B, M, d)),
+    scale_chol = scale_chol,
+    nu = matrix(Inf, B, M),
+    alpha = array(0, c(B, M, d)),
+    skew_none = TRUE
+  )
+
+  set.seed(63)
+  torch::torch_manual_seed(63)
+  sampled <- sample_mst_pmdn(pred, num_samples = S)
+  components <- torch::as_array(sampled$components)
+
+  expect_equal(as.integer(sampled$samples$size()), c(S, B, d))
+  expect_equal(as.integer(sampled$components$size()), c(S, B))
+  for (b in seq_len(B)) {
+    observed <- tabulate(components[, b], nbins = M) / S
+    expect_equal(observed, probabilities, tolerance = 0.02)
+  }
+})
+
+test_that("symmetric sampling is reproducible within the implementation", {
+  pred <- make_mdn_output(
+    pi = matrix(c(0.35, 0.65), 1, 2),
+    mu = array(c(-1, 1), c(1, 2, 1)),
+    scale_chol = array(1, c(1, 2, 1, 1)),
+    nu = matrix(c(Inf, 9), 1, 2),
+    alpha = array(0, c(1, 2, 1)),
+    skew_none = TRUE
+  )
+
+  set.seed(731)
+  torch::torch_manual_seed(731)
+  first <- sample_mst_pmdn(pred, num_samples = 20)
+  set.seed(731)
+  torch::torch_manual_seed(731)
+  second <- sample_mst_pmdn(pred, num_samples = 20)
+
+  expect_equal(
+    torch::as_array(first$samples),
+    torch::as_array(second$samples),
+    tolerance = 0
+  )
+  expect_equal(
+    torch::as_array(first$components),
+    torch::as_array(second$components),
+    tolerance = 0
+  )
+})

--- a/tests/testthat/test-skew-none-fast-path.R
+++ b/tests/testthat/test-skew-none-fast-path.R
@@ -1,0 +1,359 @@
+make_zero_skew_output <- function(B = 2L, M = 2L, d = 3L,
+                                  nu_values = 8, skew_none = NULL) {
+  weights <- seq_len(M)
+  weights <- weights / sum(weights)
+  pi <- matrix(rep(weights, B), nrow = B, byrow = TRUE)
+  mu <- array(
+    seq(-0.2, 0.2, length.out = B * M * d),
+    dim = c(B, M, d)
+  )
+  scale_chol <- array(0, dim = c(B, M, d, d))
+  for (b in seq_len(B)) {
+    for (m in seq_len(M)) {
+      scale_chol[b, m, , ] <- diag(
+        0.8 + 0.05 * seq_len(d),
+        nrow = d,
+        ncol = d
+      )
+    }
+  }
+  nu <- matrix(
+    rep(nu_values, length.out = B * M),
+    nrow = B,
+    byrow = TRUE
+  )
+  make_mdn_output(
+    pi = pi,
+    mu = mu,
+    scale_chol = scale_chol,
+    nu = nu,
+    alpha = array(0, dim = c(B, M, d)),
+    skew_none = skew_none
+  )
+}
+
+test_that("forward and prediction outputs propagate the structural flag", {
+  model <- define_mst_pmdn(
+    input_dim = 2,
+    output_dim = 1,
+    hidden_dim = c(3),
+    n_mixtures = 2,
+    constraint = "VIINN"
+  )
+  pred <- predict_mst_pmdn(model, matrix(0, nrow = 3, ncol = 2))
+  expect_identical(pred$skew_none, TRUE)
+
+  # A symmetric sampler must not transfer or gather alpha.
+  pred$alpha <- structure("unused alpha sentinel", class = "unused_alpha")
+  expect_no_error(sample_mst_pmdn(pred, num_samples = 2))
+
+  seen <- logical()
+  original_sampler <- MST.PMDN::sample_mst_pmdn
+  testthat::local_mocked_bindings(
+    sample_mst_pmdn = function(mdn_output, ...) {
+      seen <<- c(seen, mdn_output$skew_none)
+      original_sampler(mdn_output, ...)
+    },
+    .package = "MST.PMDN"
+  )
+
+  expect_no_error(sample_mst_pmdn_df(pred, num_samples = 2))
+  expect_no_error(cdf_marginal_mst_pmdn(
+    pred, y = 0, num_samples = 3
+  ))
+  expect_no_error(quantile_marginal_mst_pmdn(
+    pred, probs = matrix(0.5, nrow = 3), num_samples = 3
+  ))
+  expect_identical(seen, rep(TRUE, 3))
+})
+
+test_that("skew_none validation accepts absence and rejects malformed values", {
+  expect_identical(
+    MST.PMDN:::.validate_skew_none(list()),
+    FALSE
+  )
+  expect_identical(
+    MST.PMDN:::.validate_skew_none(list(skew_none = TRUE)),
+    TRUE
+  )
+  expect_identical(
+    MST.PMDN:::.validate_skew_none(list(skew_none = FALSE)),
+    FALSE
+  )
+
+  pred <- make_zero_skew_output(skew_none = TRUE)
+  target <- torch::torch_zeros(c(2, 3))
+  malformed <- list(
+    NA,
+    0,
+    1,
+    "TRUE",
+    c(TRUE, FALSE)
+  )
+  for (value in malformed) {
+    loss_output <- pred
+    loss_output$skew_none <- value
+    expect_error(
+      loss_mst_pmdn(loss_output, target),
+      "output\\$skew_none must be a single non-missing logical value\\."
+    )
+
+    sample_output <- pred
+    sample_output$skew_none <- value
+    expect_error(
+      sample_mst_pmdn(sample_output, num_samples = 1),
+      "mdn_output\\$skew_none must be a single non-missing logical value\\."
+    )
+  }
+})
+
+test_that("symmetric loss matches the zero-alpha general formulation", {
+  cases <- list(
+    list(B = 3L, M = 1L, d = 1L, nu = 7),
+    list(B = 2L, M = 3L, d = 3L, nu = c(4, 11, 30)),
+    list(B = 2L, M = 2L, d = 5L, nu = c(Inf, 9)),
+    list(B = 3L, M = 4L, d = 2L, nu = c(Inf, 5, 15, Inf))
+  )
+
+  for (case in cases) {
+    fast <- make_zero_skew_output(
+      B = case$B, M = case$M, d = case$d,
+      nu_values = case$nu, skew_none = TRUE
+    )
+    general <- make_zero_skew_output(
+      B = case$B, M = case$M, d = case$d,
+      nu_values = case$nu, skew_none = FALSE
+    )
+    target <- torch::torch_tensor(
+      matrix(
+        seq(-0.4, 0.6, length.out = case$B * case$d),
+        nrow = case$B
+      ),
+      dtype = torch::torch_float()
+    )
+
+    expect_equal(
+      loss_mst_pmdn(fast, target)$item(),
+      loss_mst_pmdn(general, target)$item(),
+      tolerance = 2e-6,
+      info = sprintf("B=%d, M=%d, d=%d", case$B, case$M, case$d)
+    )
+  }
+})
+
+make_loss_gradient_case <- function(skew_none) {
+  B <- 3L
+  M <- 2L
+  d <- 3L
+  logits <- torch::torch_tensor(
+    matrix(c(0.2, -0.1, -0.3, 0.4, 0.1, -0.2), nrow = B, byrow = TRUE),
+    dtype = torch::torch_float(),
+    requires_grad = TRUE
+  )
+  mu <- torch::torch_tensor(
+    array(seq(-0.25, 0.3, length.out = B * M * d), c(B, M, d)),
+    dtype = torch::torch_float(),
+    requires_grad = TRUE
+  )
+  scale_chol_values <- array(0, c(B, M, d, d))
+  for (b in seq_len(B)) {
+    for (m in seq_len(M)) {
+      scale_chol_values[b, m, , ] <- matrix(
+        c(
+          0.9, 0, 0,
+          0.1, 1.1, 0,
+          -0.05, 0.15, 0.8
+        ),
+        nrow = d,
+        byrow = TRUE
+      )
+    }
+  }
+  scale_chol <- torch::torch_tensor(
+    scale_chol_values,
+    dtype = torch::torch_float(),
+    requires_grad = TRUE
+  )
+  nu <- torch::torch_tensor(
+    matrix(c(6, 14, 7, 16, 8, 18), nrow = B, byrow = TRUE),
+    dtype = torch::torch_float(),
+    requires_grad = TRUE
+  )
+  output <- list(
+    pi = torch::nnf_softmax(logits, dim = 2),
+    mu = mu,
+    scale_chol = scale_chol,
+    nu = nu,
+    alpha = torch::torch_zeros(c(B, M, d)),
+    skew_none = skew_none
+  )
+  list(
+    output = output,
+    leaves = list(
+      mixture_logits = logits,
+      locations = mu,
+      scale_chol = scale_chol,
+      nu = nu
+    )
+  )
+}
+
+test_that("symmetric bypass preserves all non-alpha gradients", {
+  fast <- make_loss_gradient_case(TRUE)
+  general <- make_loss_gradient_case(FALSE)
+  target <- torch::torch_tensor(
+    matrix(seq(-0.5, 0.7, length.out = 9), nrow = 3),
+    dtype = torch::torch_float()
+  )
+
+  fast_loss <- loss_mst_pmdn(fast$output, target)
+  general_loss <- loss_mst_pmdn(general$output, target)
+  expect_equal(fast_loss$item(), general_loss$item(), tolerance = 2e-6)
+  fast_loss$backward()
+  general_loss$backward()
+
+  for (name in names(fast$leaves)) {
+    fast_grad <- torch::as_array(fast$leaves[[name]]$grad)
+    general_grad <- torch::as_array(general$leaves[[name]]$grad)
+    expect_true(all(is.finite(fast_grad)), info = name)
+    expect_true(all(is.finite(general_grad)), info = name)
+    expect_equal(fast_grad, general_grad, tolerance = 2e-5, info = name)
+  }
+})
+
+test_that("loss bypass control flow follows only a valid true flag", {
+  pred <- make_zero_skew_output(B = 2, M = 2, d = 3, skew_none = TRUE)
+  target <- torch::torch_zeros(c(2, 3))
+  calls <- 0L
+  testthat::local_mocked_bindings(
+    .log_skew_factor_mst = function(alpha, v, nu_safe, maha, normal, d) {
+      calls <<- calls + 1L
+      torch::torch_zeros_like(maha)
+    },
+    .package = "MST.PMDN"
+  )
+
+  loss_mst_pmdn(pred, target)
+  expect_identical(calls, 0L)
+
+  pred$skew_none <- FALSE
+  loss_mst_pmdn(pred, target)
+  expect_identical(calls, 1L)
+
+  pred$skew_none <- NULL
+  loss_mst_pmdn(pred, target)
+  expect_identical(calls, 2L)
+})
+
+test_that("inactive penalties allocate no tensors or alpha reduction graph", {
+  pred <- make_zero_skew_output(
+    B = 2, M = 2, d = 3, nu_values = 8, skew_none = TRUE
+  )
+  pred$alpha <- structure("unused alpha sentinel", class = "unused_alpha")
+  target <- torch::torch_zeros(c(2, 3))
+  tensor_calls <- 0L
+  original_tensor <- torch::torch_tensor
+  testthat::local_mocked_bindings(
+    torch_tensor = function(...) {
+      tensor_calls <<- tensor_calls + 1L
+      original_tensor(...)
+    },
+    .package = "MST.PMDN"
+  )
+
+  expect_no_error(loss_mst_pmdn(pred, target))
+  expect_identical(tensor_calls, 0L)
+
+  expect_no_error(loss_mst_pmdn(pred, target, lambda_alpha = 0.5))
+  expect_identical(tensor_calls, 0L)
+
+  expect_no_error(loss_mst_pmdn(pred, target, lambda_nu_inv = 0.5))
+  expect_identical(tensor_calls, 1L)
+})
+
+test_that("loss validates penalty weights and requires alpha", {
+  pred <- make_zero_skew_output(
+    B = 2, M = 2, d = 3, nu_values = 8, skew_none = TRUE
+  )
+  target <- torch::torch_zeros(c(2, 3))
+  invalid <- list(
+    NA_real_,
+    NaN,
+    Inf,
+    -Inf,
+    -0.1,
+    numeric(),
+    c(0, 1),
+    "0",
+    FALSE,
+    torch::torch_tensor(0)
+  )
+
+  for (value in invalid) {
+    expect_error(
+      loss_mst_pmdn(pred, target, lambda_alpha = value),
+      "lambda_alpha must be a single finite non-negative numeric value\\."
+    )
+    expect_error(
+      loss_mst_pmdn(pred, target, lambda_nu_inv = value),
+      "lambda_nu_inv must be a single finite non-negative numeric value\\."
+    )
+  }
+
+  missing_alpha <- pred
+  missing_alpha$alpha <- NULL
+  expect_error(
+    loss_mst_pmdn(missing_alpha, target),
+    "output\\$alpha is required\\."
+  )
+})
+
+test_that("sampler requires alpha for every skew_none state", {
+  for (skew_none in list(TRUE, FALSE, NULL)) {
+    pred <- make_zero_skew_output(skew_none = skew_none)
+    pred$alpha <- NULL
+    expect_error(
+      sample_mst_pmdn(pred, num_samples = 1),
+      "mdn_output\\$alpha is required\\."
+    )
+  }
+})
+
+test_that("sampler bypass draws one latent tensor and never reads alpha", {
+  B <- 2L
+  S <- 4L
+  d <- 3L
+  shapes <- list()
+  original_randn <- torch::torch_randn
+  testthat::local_mocked_bindings(
+    torch_randn = function(...) {
+      args <- list(...)
+      shapes[[length(shapes) + 1L]] <<- as.integer(args[[1]])
+      do.call(original_randn, args)
+    },
+    .package = "MST.PMDN"
+  )
+
+  fast <- make_zero_skew_output(
+    B = B, M = 2, d = d, nu_values = Inf, skew_none = TRUE
+  )
+  fast$alpha <- structure("unused alpha sentinel", class = "unused_alpha")
+  expect_no_error(sample_mst_pmdn(fast, num_samples = S))
+  expect_equal(shapes, list(c(B, S, d)))
+
+  general <- make_zero_skew_output(
+    B = B, M = 2, d = d, nu_values = Inf, skew_none = FALSE
+  )
+  expect_no_error(sample_mst_pmdn(general, num_samples = S))
+  expect_equal(
+    shapes[2:3],
+    list(c(B, S, 1L), c(B, S, d))
+  )
+
+  general$skew_none <- NULL
+  expect_no_error(sample_mst_pmdn(general, num_samples = S))
+  expect_equal(
+    shapes[4:5],
+    list(c(B, S, 1L), c(B, S, d))
+  )
+})

--- a/tests/testthat/test-skew-none-fast-path.R
+++ b/tests/testthat/test-skew-none-fast-path.R
@@ -357,3 +357,346 @@ test_that("sampler bypass draws one latent tensor and never reads alpha", {
     list(c(B, S, 1L), c(B, S, d))
   )
 })
+
+convert_output_dtype <- function(output, dtype) {
+  tensor_fields <- c("pi", "mu", "scale_chol", "nu", "alpha")
+  for (name in tensor_fields) {
+    output[[name]] <- output[[name]]$to(dtype = dtype)
+  }
+  output
+}
+
+test_that("the extracted skew factor preserves floating-point dtype", {
+  for (dtype in list(torch::torch_float(), torch::torch_double())) {
+    alpha <- torch::torch_full(
+      c(2, 2, 3), 0.25, dtype = dtype, requires_grad = TRUE
+    )
+    v <- torch::torch_full(c(2, 2, 3), -0.4, dtype = dtype)
+    nu_safe <- torch::torch_tensor(
+      matrix(c(8, 3, 12, 3), nrow = 2, byrow = TRUE),
+      dtype = dtype
+    )
+    maha <- torch::torch_tensor(
+      matrix(c(0.5, 1.5, 2.5, 3.5), nrow = 2, byrow = TRUE),
+      dtype = dtype
+    )
+    normal <- torch::torch_tensor(
+      matrix(c(FALSE, TRUE, FALSE, TRUE), nrow = 2, byrow = TRUE),
+      dtype = torch::torch_bool()
+    )
+
+    value <- MST.PMDN:::.log_skew_factor_mst(
+      alpha = alpha,
+      v = v,
+      nu_safe = nu_safe,
+      maha = maha,
+      normal = normal,
+      d = 3L
+    )
+    expect_identical(as.character(value$dtype), as.character(dtype))
+    value$sum()$backward()
+    expect_identical(as.character(alpha$grad$dtype), as.character(dtype))
+    expect_true(all(is.finite(torch::as_array(alpha$grad))))
+  }
+})
+
+test_that("sampler latent normals and returned samples follow mu dtype", {
+  randn_dtypes <- character()
+  gamma_dtypes <- character()
+  original_randn <- torch::torch_randn
+  original_gamma <- MST.PMDN:::sample_gamma
+  testthat::local_mocked_bindings(
+    torch_randn = function(...) {
+      args <- list(...)
+      randn_dtypes <<- c(randn_dtypes, as.character(args$dtype))
+      do.call(original_randn, args)
+    },
+    sample_gamma = function(...) {
+      value <- original_gamma(...)
+      gamma_dtypes <<- c(gamma_dtypes, as.character(value$dtype))
+      value
+    },
+    .package = "MST.PMDN"
+  )
+
+  fast <- convert_output_dtype(
+    make_zero_skew_output(
+      B = 2, M = 2, d = 3, nu_values = 8, skew_none = TRUE
+    ),
+    torch::torch_double()
+  )
+  fast_draws <- sample_mst_pmdn(fast, num_samples = 4)
+  expect_identical(as.character(fast_draws$samples$dtype), "Double")
+
+  general <- convert_output_dtype(
+    make_zero_skew_output(
+      B = 2, M = 2, d = 3, nu_values = 8, skew_none = FALSE
+    ),
+    torch::torch_double()
+  )
+  general$alpha <- torch::torch_full(
+    c(2, 2, 3), 0.5, dtype = torch::torch_double()
+  )
+  general_draws <- sample_mst_pmdn(general, num_samples = 4)
+  expect_identical(as.character(general_draws$samples$dtype), "Double")
+  expect_identical(randn_dtypes, rep("Double", 3))
+  expect_identical(gamma_dtypes, rep("Double", 2))
+})
+
+test_that("numeric Gamma scale is represented in the shape dtype", {
+  calls <- list()
+  testthat::local_mocked_bindings(
+    rgamma = function(n, shape, rate) {
+      calls[[length(calls) + 1L]] <<- list(
+        n = n,
+        shape = shape,
+        rate = rate
+      )
+      rep(1, n)
+    },
+    .package = "MST.PMDN"
+  )
+
+  shape <- torch::torch_tensor(c(2, 3), dtype = torch::torch_double())
+  scale <- 1 + 2^-30
+  draws <- MST.PMDN:::sample_gamma(shape, scale = scale)
+
+  expect_identical(as.character(draws$dtype), "Double")
+  expect_equal(calls[[1]]$shape, c(2, 3), tolerance = 0)
+  expect_equal(calls[[1]]$rate, 1 / scale, tolerance = 0)
+
+  float_draws <- MST.PMDN:::sample_gamma(c(2, 3), scale = scale)
+  expect_identical(as.character(float_draws$dtype), "Float")
+})
+
+test_that("model dtype inference handles unnamed parameter lists", {
+  parameter <- torch::torch_zeros(c(2, 2), dtype = torch::torch_double())
+  parameterless <- MST.PMDN:::.model_dtype_info(list())
+  expect_null(parameterless$dtype)
+  expect_null(parameterless$parameter_name)
+
+  unnamed <- MST.PMDN:::.model_dtype_info(unname(list(parameter)))
+  expect_identical(unnamed$parameter_name, "<unnamed>")
+  expect_identical(as.character(unnamed$dtype), "Double")
+
+  named <- MST.PMDN:::.model_dtype_info(list(weight = parameter))
+  expect_identical(named$parameter_name, "weight")
+  expect_identical(as.character(named$dtype), "Double")
+})
+
+test_that("prediction coercion follows the first named model parameter", {
+  model <- define_mst_pmdn(
+    input_dim = 2,
+    output_dim = 1,
+    hidden_dim = c(3),
+    n_mixtures = 2,
+    constraint = "VIINN"
+  )
+  model <- model$to(dtype = torch::torch_double())
+  first_parameter_name <- names(model$parameters)[[1]]
+
+  numeric_pred <- predict_mst_pmdn(
+    model,
+    matrix(seq(-1, 1, length.out = 6), nrow = 3)
+  )
+  expect_identical(as.character(numeric_pred$mu$dtype), "Double")
+
+  double_input <- torch::torch_zeros(
+    c(3, 2), dtype = torch::torch_double()
+  )
+  tensor_pred <- predict_mst_pmdn(model, double_input)
+  expect_identical(as.character(tensor_pred$mu$dtype), "Double")
+  expect_identical(as.character(double_input$dtype), "Double")
+
+  float_input <- torch::torch_zeros(c(3, 2), dtype = torch::torch_float())
+  error <- tryCatch(
+    predict_mst_pmdn(model, float_input),
+    error = identity
+  )
+  expect_s3_class(error, "error")
+  expect_true(grepl("new_inputs has dtype", conditionMessage(error), fixed = TRUE))
+  expect_true(grepl(
+    first_parameter_name, conditionMessage(error), fixed = TRUE
+  ))
+  expect_true(grepl(
+    "new_inputs$to(dtype = model$parameters[[1]]$dtype)",
+    conditionMessage(error),
+    fixed = TRUE
+  ))
+  expect_identical(as.character(float_input$dtype), "Float")
+})
+
+test_that("image prediction coercion and mismatch diagnostics use model dtype", {
+  image_dtype_module <- torch::nn_module(
+    "image_dtype_module",
+    initialize = function() {
+      self$output_dim <- 2
+      self$projection <- torch::nn_linear(4, 2)
+    },
+    forward = function(x) {
+      self$projection(x$reshape(c(x$size(1), 4)))
+    }
+  )
+  model <- define_mst_pmdn(
+    input_dim = 2,
+    output_dim = 1,
+    hidden_dim = c(3),
+    n_mixtures = 1,
+    constraint = "VIINN",
+    image_module = image_dtype_module()
+  )
+  model <- model$to(dtype = torch::torch_double())
+  first_parameter_name <- names(model$parameters)[[1]]
+
+  pred <- predict_mst_pmdn(
+    model,
+    matrix(0, nrow = 3, ncol = 2),
+    image_inputs = array(0, dim = c(3, 1, 2, 2))
+  )
+  expect_identical(as.character(pred$mu$dtype), "Double")
+
+  image_tensor <- torch::torch_zeros(
+    c(3, 1, 2, 2), dtype = torch::torch_float()
+  )
+  error <- tryCatch(
+    predict_mst_pmdn(
+      model,
+      torch::torch_zeros(c(3, 2), dtype = torch::torch_double()),
+      image_inputs = image_tensor
+    ),
+    error = identity
+  )
+  expect_s3_class(error, "error")
+  expect_true(grepl(
+    "image_inputs has dtype", conditionMessage(error), fixed = TRUE
+  ))
+  expect_true(grepl(
+    first_parameter_name, conditionMessage(error), fixed = TRUE
+  ))
+  expect_true(grepl(
+    "image_inputs$to(dtype = model$parameters[[1]]$dtype)",
+    conditionMessage(error),
+    fixed = TRUE
+  ))
+  expect_identical(as.character(image_tensor$dtype), "Float")
+})
+
+test_that("parameterless prediction retains legacy input coercion", {
+  parameterless_module <- torch::nn_module(
+    "parameterless_module",
+    forward = function(x, image = NULL) {
+      list(tabular = x, image = image)
+    }
+  )
+  model <- parameterless_module()
+
+  coerced <- predict_mst_pmdn(
+    model,
+    matrix(0, 2, 2),
+    image_inputs = array(0, dim = c(2, 1, 2, 2))
+  )
+  expect_identical(as.character(coerced$tabular$dtype), "Float")
+  expect_identical(as.character(coerced$image$dtype), "Float")
+
+  tabular_tensor <- torch::torch_zeros(
+    c(2, 2), dtype = torch::torch_double()
+  )
+  image_tensor <- torch::torch_zeros(
+    c(2, 1, 2, 2), dtype = torch::torch_double()
+  )
+  retained <- predict_mst_pmdn(
+    model,
+    tabular_tensor,
+    image_inputs = image_tensor
+  )
+  expect_identical(as.character(retained$tabular$dtype), "Double")
+  expect_identical(as.character(retained$image$dtype), "Double")
+  expect_identical(as.character(tabular_tensor$dtype), "Double")
+  expect_identical(as.character(image_tensor$dtype), "Double")
+})
+
+test_that("float64 loss retains dtype and finite backward gradients", {
+  model <- define_mst_pmdn(
+    input_dim = 2,
+    output_dim = 3,
+    hidden_dim = c(4),
+    n_mixtures = 2,
+    constraint = "VIIVV"
+  )
+  model <- model$to(dtype = torch::torch_double())
+  input <- torch::torch_tensor(
+    matrix(seq(-1, 1, length.out = 12), nrow = 6),
+    dtype = torch::torch_double()
+  )
+  target <- torch::torch_tensor(
+    matrix(seq(-0.7, 0.8, length.out = 18), nrow = 6),
+    dtype = torch::torch_double()
+  )
+
+  output <- model(input)
+  loss <- loss_mst_pmdn(output, target)
+  expect_identical(as.character(loss$dtype), "Double")
+  expect_true(is.finite(loss$item()))
+  loss$backward()
+
+  bias_parameters <- list(
+    mixture = model$fc_pi$bias,
+    location = model$fc_mu$bias,
+    scale = model$fc_L$bias,
+    nu = model$fc_nu$bias,
+    alpha = model$fc_alpha$bias
+  )
+  for (name in names(bias_parameters)) {
+    gradient <- torch::as_array(bias_parameters[[name]]$grad)
+    expect_true(all(is.finite(gradient)), info = name)
+  }
+})
+
+test_that("dtype paths run on an available CUDA backend", {
+  testthat::skip_if(!torch::cuda_is_available(), "CUDA is not available")
+  model <- define_mst_pmdn(
+    input_dim = 2,
+    output_dim = 1,
+    hidden_dim = c(3),
+    n_mixtures = 1,
+    constraint = "VIINN"
+  )
+  model <- model$to(dtype = torch::torch_double(), device = "cuda")
+  pred <- predict_mst_pmdn(
+    model,
+    matrix(0, nrow = 2, ncol = 2),
+    device = "cuda"
+  )
+  expect_identical(as.character(pred$mu$dtype), "Double")
+  draws <- sample_mst_pmdn(pred, num_samples = 3, device = "cuda")
+  expect_identical(as.character(draws$samples$dtype), "Double")
+  expect_true(draws$samples$is_cuda)
+
+  for (dtype in list(torch::torch_float(), torch::torch_double())) {
+    alpha <- torch::torch_full(
+      c(2, 2, 3), 0.25, dtype = dtype, device = "cuda"
+    )
+    v <- torch::torch_full(
+      c(2, 2, 3), -0.4, dtype = dtype, device = "cuda"
+    )
+    nu_safe <- torch::torch_full(
+      c(2, 2), 8, dtype = dtype, device = "cuda"
+    )
+    maha <- torch::torch_full(
+      c(2, 2), 0.5, dtype = dtype, device = "cuda"
+    )
+    normal <- torch::torch_zeros(
+      c(2, 2), dtype = torch::torch_bool(), device = "cuda"
+    )
+    value <- MST.PMDN:::.log_skew_factor_mst(
+      alpha = alpha,
+      v = v,
+      nu_safe = nu_safe,
+      maha = maha,
+      normal = normal,
+      d = 3L
+    )
+    expect_identical(as.character(value$dtype), as.character(dtype))
+    expect_true(value$is_cuda)
+  }
+})

--- a/tests/testthat/test-training-state.R
+++ b/tests/testthat/test-training-state.R
@@ -42,6 +42,7 @@ test_that("validation uses every case and is batch-size invariant", {
   expect_equal(fit_a$val_loss_history, fit_b$val_loss_history,
                tolerance = 1e-6)
   pred <- predict_mst_pmdn(fit_a$model, x[split$validation, , drop = FALSE])
+  expect_identical(pred$skew_none, TRUE)
   manual_loss <- loss_mst_pmdn(
     pred,
     torch::torch_tensor(y[split$validation, , drop = FALSE],
@@ -123,4 +124,8 @@ test_that("checkpoint resume reproduces uninterrupted training", {
   expect_null(latest$schema_version)
   expect_null(best$schema_version)
   expect_false(identical(resumed_path, fit_resumed$best_checkpoint_path))
+  expect_identical(
+    predict_mst_pmdn(fit_resumed$model, x[1:2, , drop = FALSE])$skew_none,
+    TRUE
+  )
 })

--- a/tools/benchmark-skew-none-fast-path.R
+++ b/tools/benchmark-skew-none-fast-path.R
@@ -1,0 +1,263 @@
+# Benchmark the structural skew-none fast paths without adding timing
+# assertions to the test suite. Run from the package root with:
+#
+#   Rscript tools/benchmark-skew-none-fast-path.R
+#
+# The recursive configuration intentionally repeats B = S = 1 sampling
+# 36,200 times. Override that count only for a smoke run with the
+# MST_PMDN_BENCH_RECURSIVE_REPS environment variable.
+
+if (!requireNamespace("torch", quietly = TRUE)) {
+  stop("The torch package is required.")
+}
+if (!requireNamespace("MST.PMDN", quietly = TRUE)) {
+  if (!requireNamespace("pkgload", quietly = TRUE)) {
+    stop("Install MST.PMDN or pkgload before running this script.")
+  }
+  pkgload::load_all(".", quiet = TRUE)
+} else {
+  suppressPackageStartupMessages(library(MST.PMDN))
+}
+
+recursive_repetitions <- as.integer(Sys.getenv(
+  "MST_PMDN_BENCH_RECURSIVE_REPS", "36200"
+))
+if (is.na(recursive_repetitions) || recursive_repetitions < 1L) {
+  stop("MST_PMDN_BENCH_RECURSIVE_REPS must be a positive integer.")
+}
+
+available_devices <- "cpu"
+if (torch::cuda_is_available()) {
+  available_devices <- c(available_devices, "cuda")
+}
+
+sync_device <- function(device) {
+  if (identical(device, "cuda")) {
+    torch::cuda_synchronize()
+  }
+}
+
+make_output <- function(B, M, d, nu_value, alpha_value, skew_none, device) {
+  dtype <- torch::torch_float()
+  pi <- torch::torch_full(
+    c(B, M), 1 / M, dtype = dtype, device = device
+  )
+  mu <- torch::torch_zeros(c(B, M, d), dtype = dtype, device = device)
+  scale_chol <- torch::torch_eye(d, dtype = dtype, device = device)$
+    reshape(c(1, 1, d, d))$expand(c(B, M, d, d))$clone()
+  nu <- torch::torch_full(
+    c(B, M), nu_value, dtype = dtype, device = device
+  )
+  alpha <- torch::torch_full(
+    c(B, M, d), alpha_value, dtype = dtype, device = device
+  )
+  list(
+    pi = pi,
+    mu = mu,
+    scale_chol = scale_chol,
+    nu = nu,
+    alpha = alpha,
+    skew_none = skew_none
+  )
+}
+
+allocation_count <- function(fun, repetitions) {
+  if (!isTRUE(capabilities("profmem"))) {
+    return(NA_integer_)
+  }
+  profile <- tempfile(fileext = ".out")
+  on.exit(unlink(profile), add = TRUE)
+  Rprofmem(profile)
+  on.exit(Rprofmem(NULL), add = TRUE)
+  for (i in seq_len(repetitions)) {
+    fun()
+  }
+  Rprofmem(NULL)
+  length(readLines(profile, warn = FALSE))
+}
+
+benchmark_call <- function(fun, repetitions, device) {
+  invisible(gc())
+  sync_device(device)
+  elapsed <- system.time({
+    for (i in seq_len(repetitions)) {
+      fun()
+    }
+    sync_device(device)
+  })[["elapsed"]]
+  allocation_repetitions <- min(repetitions, 100L)
+  allocations <- allocation_count(fun, allocation_repetitions)
+  data.frame(
+    repetitions = repetitions,
+    elapsed_seconds = elapsed,
+    microseconds_per_call = 1e6 * elapsed / repetitions,
+    allocations_profiled = allocations,
+    allocation_repetitions = allocation_repetitions
+  )
+}
+
+sampling_configs <- list(
+  recursive = list(B = 1L, S = 1L, repetitions = recursive_repetitions),
+  single_batch = list(B = 1L, S = 512L, repetitions = 200L),
+  large_batch = list(B = 64L, S = 2048L, repetitions = 20L)
+)
+distributions <- list(
+  symmetric_gaussian = list(nu = Inf, alpha = 0, skew_none = TRUE),
+  symmetric_t = list(nu = 8, alpha = 0, skew_none = TRUE),
+  skew_enabled = list(nu = 8, alpha = 0.75, skew_none = FALSE)
+)
+
+sampling_results <- list()
+for (device in available_devices) {
+  for (config_name in names(sampling_configs)) {
+    config <- sampling_configs[[config_name]]
+    for (distribution_name in names(distributions)) {
+      distribution <- distributions[[distribution_name]]
+      fast_output <- make_output(
+        B = config$B, M = 6L, d = 2L,
+        nu_value = distribution$nu,
+        alpha_value = distribution$alpha,
+        skew_none = distribution$skew_none,
+        device = device
+      )
+      paths <- if (distribution$skew_none) {
+        list(fast = fast_output, general_zero_alpha = within(
+          fast_output, skew_none <- FALSE
+        ))
+      } else {
+        list(general_skew = fast_output)
+      }
+      for (path_name in names(paths)) {
+        output <- paths[[path_name]]
+        result <- benchmark_call(
+          function() {
+            MST.PMDN::sample_mst_pmdn(
+              output, num_samples = config$S, device = device
+            )
+          },
+          repetitions = config$repetitions,
+          device = device
+        )
+        result$device <- device
+        result$operation <- "sample"
+        result$config <- config_name
+        result$distribution <- distribution_name
+        result$path <- path_name
+        sampling_results[[length(sampling_results) + 1L]] <- result
+      }
+    }
+  }
+}
+sampling_results <- do.call(rbind, sampling_results)
+
+make_loss_graph <- function(template, target_values, train_nu, train_alpha) {
+  clone_leaf <- function(x, requires_grad) {
+    x <- x$detach()$clone()
+    if (requires_grad) {
+      x$requires_grad_(TRUE)
+    }
+    x
+  }
+  output <- list(
+    pi = clone_leaf(template$pi, TRUE),
+    mu = clone_leaf(template$mu, TRUE),
+    scale_chol = clone_leaf(template$scale_chol, TRUE),
+    nu = clone_leaf(template$nu, train_nu),
+    alpha = clone_leaf(template$alpha, train_alpha),
+    skew_none = template$skew_none
+  )
+  list(output = output, target = target_values)
+}
+
+loss_results <- list()
+for (device in available_devices) {
+  target <- torch::torch_zeros(
+    c(256, 2), dtype = torch::torch_float(), device = device
+  )
+  for (distribution_name in names(distributions)) {
+    distribution <- distributions[[distribution_name]]
+    template <- make_output(
+      B = 256L, M = 6L, d = 2L,
+      nu_value = distribution$nu,
+      alpha_value = distribution$alpha,
+      skew_none = distribution$skew_none,
+      device = device
+    )
+    paths <- if (distribution$skew_none) {
+      list(fast = template, general_zero_alpha = within(
+        template, skew_none <- FALSE
+      ))
+    } else {
+      list(general_skew = template)
+    }
+    for (path_name in names(paths)) {
+      path_template <- paths[[path_name]]
+      forward_result <- benchmark_call(
+        function() {
+          graph <- make_loss_graph(
+            path_template, target,
+            train_nu = is.finite(distribution$nu),
+            train_alpha = !distribution$skew_none
+          )
+          MST.PMDN::loss_mst_pmdn(graph$output, graph$target)
+        },
+        repetitions = 500L,
+        device = device
+      )
+      forward_result$device <- device
+      forward_result$operation <- "loss_forward"
+      forward_result$config <- "B256_M6_d2"
+      forward_result$distribution <- distribution_name
+      forward_result$path <- path_name
+      loss_results[[length(loss_results) + 1L]] <- forward_result
+
+      backward_result <- benchmark_call(
+        function() {
+          graph <- make_loss_graph(
+            path_template, target,
+            train_nu = is.finite(distribution$nu),
+            train_alpha = !distribution$skew_none
+          )
+          loss <- MST.PMDN::loss_mst_pmdn(graph$output, graph$target)
+          loss$backward()
+        },
+        repetitions = 100L,
+        device = device
+      )
+      backward_result$device <- device
+      backward_result$operation <- "loss_forward_backward"
+      backward_result$config <- "B256_M6_d2"
+      backward_result$distribution <- distribution_name
+      backward_result$path <- path_name
+      loss_results[[length(loss_results) + 1L]] <- backward_result
+    }
+  }
+}
+loss_results <- do.call(rbind, loss_results)
+
+results <- rbind(sampling_results, loss_results)
+results$relative_speedup <- NA_real_
+group_columns <- c("device", "operation", "config", "distribution")
+groups <- interaction(results[group_columns], drop = TRUE)
+for (group in unique(groups)) {
+  rows <- which(groups == group)
+  fast <- rows[results$path[rows] == "fast"]
+  general <- rows[results$path[rows] == "general_zero_alpha"]
+  if (length(fast) == 1L && length(general) == 1L) {
+    results$relative_speedup[fast] <-
+      results$elapsed_seconds[general] / results$elapsed_seconds[fast]
+  }
+}
+
+results <- results[
+  c(
+    "device", "operation", "config", "distribution", "path",
+    "repetitions", "elapsed_seconds", "microseconds_per_call",
+    "allocations_profiled", "allocation_repetitions", "relative_speedup"
+  )
+]
+output_path <- Sys.getenv("MST_PMDN_BENCH_OUTPUT", "")
+if (nzchar(output_path)) {
+  utils::write.csv(results, output_path, row.names = FALSE)
+}
+print(results, row.names = FALSE)


### PR DESCRIPTION
## Summary

- emit and validate a structural `skew_none` flag while retaining the zero `alpha` tensor for compatibility
- bypass the skew-factor calculation in `loss_mst_pmdn()` and the skew-normal construction, alpha transfer/gather, and redundant scalar-normal draw in `sample_mst_pmdn()` for `"N"` skewness models
- avoid constructing inactive alpha and inverse-nu penalty graphs; the structural alpha penalty is skipped identically under `skew_none = TRUE`
- validate both penalty weights as finite non-negative numeric scalars and require `alpha` on every loss and sampler path through a shared name-aware helper
- preserve the general path for legacy outputs, malformed-flag validation, numerically zero skew-enabled models, and constant skewness
- make normal and Gamma sampler latents follow the model dtype, represent ordinary numeric Gamma scales in the shape dtype, and vectorize the CPU `rgamma()` call
- infer prediction coercion dtype defensively from the first model parameter, including unnamed parameter lists; parameterless modules retain legacy float32 coercion for ordinary R inputs and preserve supplied tensor precision
- make tensor-dtype mismatch diagnostics name the inferred parameter and show the explicit `$to(dtype = ...)` remedy
- document the caller invariant that hand-built outputs may set `skew_none = TRUE` only when `alpha` is structurally zero
- document the RNG-stream change and bump the package to 0.2.1

## Why

The `"N"` skewness constraint omits the alpha head and emits an identically zero alpha tensor, but the loss and sampler still performed the complete skew calculation. Those operations contribute neither value nor trainable-parameter gradient. Separately, sampler latents and non-tensor prediction inputs defaulted to float32, so float64 models relied on implicit promotion or carried float32 Gamma noise through a promoted Double result.

## Commit structure

1. `93ae809` — structural fast path, guarded and validated penalties, required-output contracts, distribution/control-flow coverage, and standalone benchmarks
2. `bdb70a5` — normal/Gamma sampler and predictor dtype corrections, numeric-scale precision, parameterless-module compatibility, actionable mismatch diagnostics, NEWS, and version bump

## Validation

- both remote commit trees exactly match their corresponding local Git trees
- `git diff --check origin/main..HEAD` passes
- loss-value and non-alpha-gradient equivalence cover finite t, exact Gaussian, mixed, multi-component, and odd-dimensional cases
- tests directly mock the extracted skew factor, penalty scalar construction, latent-normal draws, and finite-nu Gamma output dtype
- invalid penalty edges, missing `alpha` in both loss and sampler, and a Double numeric scale that is not representable in float32 are direct regression cases
- the weak `log(2)` scalar is checked for float32/float64 result and gradient dtype on CPU, plus result dtype/device when CUDA is available
- sampling tests cover Gaussian and Student-t moments, nonidentity covariance, component frequencies, dimensions, and within-version RNG reproducibility
- the `N` integration tests perform real training and validation, including four uninterrupted epochs versus a two-epoch checkpoint resume
- float32, float64, tensor/non-tensor prediction, unnamed parameter lists, image input, parameterless models, checkpoint resume, and conditional CUDA paths are covered

[R CMD check run 31](https://github.com/aljaca/MST.PMDN/actions/runs/30381788833) is green: 286 passed, 2 conditional CUDA skips, 0 failures, and 0 warnings. The repository's two pre-existing notes remain for `.github` and `LICENSE` metadata.

## CPU benchmark

Measured on a GitHub-hosted Ubuntu runner with the full benchmark harness. Times are microseconds per complete call; speedup is the zero-alpha general path divided by the structural fast path.

| Operation | Configuration | Distribution | Fast | General | Speedup |
|---|---|---:|---:|---:|---:|
| sample | B=1, S=1, 36,200 calls | Gaussian | 2,111 | 3,805 | 1.80x |
| sample | B=1, S=1, 36,200 calls | finite t | 4,121 | 5,817 | 1.41x |
| sample | B=1, S=512 | Gaussian | 1,760 | 3,110 | 1.77x |
| sample | B=1, S=512 | finite t | 3,600 | 4,910 | 1.36x |
| sample | B=64, S=2,048 | Gaussian | 14,150 | 28,050 | 1.98x |
| sample | B=64, S=2,048 | finite t | 25,850 | 38,350 | 1.48x |
| loss forward | B=256, M=6, d=2 | Gaussian | 3,590 | 17,238 | 4.80x |
| loss forward | B=256, M=6, d=2 | finite t | 3,612 | 18,108 | 5.01x |
| loss forward + backward | B=256, M=6, d=2 | Gaussian | 4,370 | 17,940 | 4.11x |
| loss forward + backward | B=256, M=6, d=2 | finite t | 4,650 | 18,180 | 3.91x |

The finite-t sampler includes the unavoidable CPU Gamma round-trip, now performed by one vectorized `rgamma()` call and returned in the model dtype. This explains its smaller relative skew-bypass gain. These are single-run timings, so the exact microsecond values are runner-dependent; the operation removal and direction of the effect are also established by direct control-flow tests.