### PR TITLE
Remove Plate analysis from XAI routines

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -28,8 +28,7 @@
 
 ## Covariate and image effects
 
-- Added one-dimensional accumulated local effects, centred ICE curves, local
-  finite-difference slopes, and Plate-style baseline-contrast/slope data.
+- Added one-dimensional accumulated local effects and centred ICE curves.
   Case-matched image rows remain fixed during tabular perturbations.
 - ALE now merges empirically empty bins, rejects mixture decomposition before
   bin evaluation, and documents its within-bin linear midpoint convention. ICE

--- a/R/explain-effects.R
+++ b/R/explain-effects.R
@@ -386,20 +386,6 @@ ale_mst_pmdn <- function(model,
   out
 }
 
-.ice_slopes_mst_pmdn <- function(grid, values) {
-  n <- length(grid)
-  if (n < 2L) return(rep(NA_real_, n))
-  slopes <- numeric(n)
-  slopes[1L] <- (values[2L] - values[1L]) / (grid[2L] - grid[1L])
-  slopes[n] <- (values[n] - values[n - 1L]) / (grid[n] - grid[n - 1L])
-  if (n > 2L) {
-    index <- 2:(n - 1L)
-    slopes[index] <- (values[index + 1L] - values[index - 1L]) /
-      (grid[index + 1L] - grid[index - 1L])
-  }
-  slopes
-}
-
 # Centred individual conditional expectation for MST-PMDN functionals
 ice_mst_pmdn <- function(model,
                          inputs,
@@ -409,7 +395,6 @@ ice_mst_pmdn <- function(model,
                          grid = NULL,
                          reference = NULL,
                          n_curves = 100L,
-                         derivative = FALSE,
                          ale = TRUE,
                          n_bins = 20L,
                          num_samples = 4096L,
@@ -468,14 +453,6 @@ ice_mst_pmdn <- function(model,
     chunk_size, device, response_names
   )
   reference_values <- reference_result$data$value
-  pred_original <- .predict_chunks_mst_pmdn(
-    model, selected_inputs, selected_images,
-    chunk_size = chunk_size, device = device
-  )
-  original_result <- .functional_values_quiet_mst_pmdn(
-    pred_original, functional, num_samples, latent_draws,
-    chunk_size, device, response_names
-  )
 
   values <- matrix(NA_real_, nrow = length(case_rows), ncol = length(grid))
   grid_diagnostics <- vector("list", length(grid))
@@ -494,33 +471,13 @@ ice_mst_pmdn <- function(model,
     grid_diagnostics[[g]] <- result$diagnostics
   }
   centred <- sweep(values, 1L, reference_values, "-")
-  slopes <- matrix(NA_real_, nrow = nrow(centred), ncol = ncol(centred))
-  if (isTRUE(derivative)) {
-    for (i in seq_len(nrow(centred))) {
-      slopes[i, ] <- .ice_slopes_mst_pmdn(grid, centred[i, ])
-    }
-  }
 
   curves <- do.call(rbind, lapply(seq_along(case_rows), function(i) {
     data.frame(
       case = case_rows[i],
       feature_value = grid,
       value = values[i, ],
-      centred = centred[i, ],
-      slope = slopes[i, ]
-    )
-  }))
-  plate <- do.call(rbind, lapply(seq_along(case_rows), function(i) {
-    x_i <- inputs_matrix[case_rows[i], feature_info$index]
-    data.frame(
-      case = case_rows[i],
-      feature_value = x_i,
-      baseline_contrast = original_result$data$value[i] - reference_values[i],
-      local_slope = if (isTRUE(derivative)) {
-        stats::approx(grid, slopes[i, ], xout = x_i, rule = 2)$y
-      } else {
-        NA_real_
-      }
+      centred = centred[i, ]
     )
   }))
   if (inherits(ale, "mst_pmdn_ale")) {
@@ -557,7 +514,6 @@ ice_mst_pmdn <- function(model,
 
   out <- list(
     curves = curves,
-    plate = plate,
     ale = ale_result,
     feature = feature_info,
     functional = functional,
@@ -565,7 +521,6 @@ ice_mst_pmdn <- function(model,
     reference = reference,
     cases = case_rows,
     settings = list(
-      derivative = isTRUE(derivative),
       ale = ale_mode,
       num_samples = if (is.null(latent_draws)) NA_integer_ else
         latent_draws$num_samples,
@@ -574,7 +529,6 @@ ice_mst_pmdn <- function(model,
     ),
     diagnostics = list(
       reference = reference_result$diagnostics,
-      original = original_result$diagnostics,
       grid = grid_diagnostics
     ),
     latent_draws = .latent_draws_for_output_mst_pmdn(latent_draws)

--- a/R/plot-explanations.R
+++ b/R/plot-explanations.R
@@ -76,31 +76,10 @@ plot.mst_pmdn_ale <- function(x,
 }
 
 plot.mst_pmdn_ice <- function(x,
-                              type = c("ice", "plate"),
                               xlab = NULL,
                               ylab = NULL,
                               main = NULL,
-                              pch = 19,
                               ...) {
-  type <- match.arg(type)
-  if (type == "plate") {
-    if (all(is.na(x$plate$local_slope))) {
-      stop("Plate-style slopes require derivative = TRUE in ice_mst_pmdn().",
-           call. = FALSE)
-    }
-    graphics::plot(
-      x$plate$baseline_contrast,
-      x$plate$local_slope,
-      pch = pch,
-      xlab = if (is.null(xlab)) "Baseline contrast" else xlab,
-      ylab = if (is.null(ylab)) "Local slope" else ylab,
-      main = main,
-      ...
-    )
-    graphics::abline(h = 0, v = 0, lty = 2, col = "grey70")
-    return(invisible(x))
-  }
-
   y_range <- range(x$curves$centred, finite = TRUE)
   graphics::plot(
     range(x$grid),

--- a/README.md
+++ b/README.md
@@ -455,7 +455,7 @@ The deep MST-PMDN implementation consists of the following key functions and mod
 #### Functions: `ale_mst_pmdn(...)` and `ice_mst_pmdn(...)`
 
 *   **Purpose:** Explain how a tabular covariate changes a selected distribution functional.
-*   **Method:** One-dimensional ALE uses non-empty empirical bins and locally supported lower-to-upper contrasts. Effects are displayed at bin midpoints by subtracting half the current bin effect, which assumes within-bin linearity rather than using the boundary-valued Apley-Zhu convention. Centred ICE shows case-level heterogeneity, an optional or precomputed ALE overlay, optional local slopes, and Plate-style baseline-contrast/slope data. A case's image remains aligned and fixed during tabular perturbations.
+*   **Method:** One-dimensional ALE uses non-empty empirical bins and locally supported lower-to-upper contrasts. Effects are displayed at bin midpoints by subtracting half the current bin effect, which assumes within-bin linearity rather than using the boundary-valued Apley-Zhu convention. Centred ICE shows case-level heterogeneity with an optional or precomputed ALE overlay. A case's image remains aligned and fixed during tabular perturbations.
 *   **Scope:** A named feature is accepted when input columns are named; otherwise use R's 1-based column indices. Deterministically linked predictors, such as sine/cosine seasonal harmonics, should be perturbed as a scientifically coherent group outside this one-dimensional API.
 
 #### Functions: `image_contrast_mst_pmdn(...)` and `image_occlusion_mst_pmdn(...)`

--- a/man/ice_mst_pmdn.Rd
+++ b/man/ice_mst_pmdn.Rd
@@ -11,7 +11,6 @@ ice_mst_pmdn(
   grid = NULL,
   reference = NULL,
   n_curves = 100L,
-  derivative = FALSE,
   ale = TRUE,
   n_bins = 20L,
   num_samples = 4096L,
@@ -31,19 +30,17 @@ ice_mst_pmdn(
   \item{reference}{Feature value at which every curve is centred. The default
   is the empirical median.}
   \item{n_curves}{Maximum number of evenly spaced input cases.}
-  \item{derivative}{If \code{TRUE}, calculate local finite-difference slopes.}
   \item{ale}{\code{TRUE} to compute an ALE overlay using all input rows,
   \code{FALSE} or \code{NULL} to omit it, or a matching precomputed
   \code{mst_pmdn_ale} object.}
   \item{n_bins}{Number of bins for the accompanying ALE overlay.}
 }
 \description{
-Calculates complete centred ICE curves, an optional ALE overlay, local slopes,
-and Plate-style baseline-contrast and local-slope data.
+Calculates complete centred ICE curves and an optional ALE overlay.
 }
 \value{
-An object of class \code{mst_pmdn_ice} with plain \code{curves} and
-\code{plate} data frames plus an optional \code{mst_pmdn_ale} object.
+An object of class \code{mst_pmdn_ice} with a plain \code{curves} data frame
+and an optional \code{mst_pmdn_ale} object.
 }
 \details{
 The same latent bank is used at every grid point. Fixed-reference ICE is

--- a/man/plot.mst_pmdn_explanations.Rd
+++ b/man/plot.mst_pmdn_explanations.Rd
@@ -28,11 +28,9 @@
 
 \method{plot}{mst_pmdn_ice}(
   x,
-  type = c("ice", "plate"),
   xlab = NULL,
   ylab = NULL,
   main = NULL,
-  pch = 19,
   ...
 )
 
@@ -86,7 +84,7 @@
   summary.}
   \item{group}{Named image channel group.}
   \item{statistic}{Numeric occlusion output column to map.}
-  \item{xlab,ylab,main,col,zlim,pch}{Standard graphical arguments. Scalar
+  \item{xlab,ylab,main,col,zlim}{Standard graphical arguments. Scalar
   labels supplied to the three-panel component plot are recycled.}
   \item{useRaster}{Logical passed to \code{\link[graphics]{image}}. It defaults
   to \code{FALSE} so patch-centre grids need not be regular.}

--- a/tests/testthat/test-explain-effects.R
+++ b/tests/testthat/test-explain-effects.R
@@ -93,7 +93,7 @@ test_that("tabular perturbations retain case-matched image rows", {
   expect_equal(result$data$ale, expected, tolerance = 1e-6)
 })
 
-test_that("centred ICE includes ALE, derivatives, and Plate data", {
+test_that("centred ICE includes the known effect and an ALE overlay", {
   x <- cbind(feature = seq(-1, 1, length.out = 21), other = 0)
   model <- explanation_test_model(slope = 3)
   bank <- latent_draws_mst_pmdn(128L, output_dim = 1L, seed = 23)
@@ -105,17 +105,18 @@ test_that("centred ICE includes ALE, derivatives, and Plate data", {
     grid = seq(-1, 1, length.out = 7),
     reference = 0,
     n_curves = 5L,
-    derivative = TRUE,
     n_bins = 5L,
     latent_draws = bank
   )
   expect_equal(
-    result$curves$slope,
-    rep(3, nrow(result$curves)),
+    result$curves$centred,
+    3 * result$curves$feature_value,
     tolerance = 1e-6
   )
-  expect_equal(result$plate$local_slope, rep(3, nrow(result$plate)),
-               tolerance = 1e-6)
+  expect_identical(
+    names(result$curves),
+    c("case", "feature_value", "value", "centred")
+  )
   expect_s3_class(result$ale, "mst_pmdn_ale")
   expect_false(".cache" %in% names(result$latent_draws))
   expect_false(".cache" %in% names(result$ale$latent_draws))

--- a/tests/testthat/test-plot-explanations.R
+++ b/tests/testthat/test-plot-explanations.R
@@ -46,23 +46,13 @@ test_that("all explanation plot methods smoke-test with graphical overrides", {
     functional = mst_functional("mean", 1L),
     grid = c(-1, 0, 1),
     n_curves = 3L,
-    derivative = TRUE,
     ale = FALSE
   )
   expect_invisible(plot(
     ice,
-    type = "ice",
     main = "ICE",
     xlab = "Predictor",
     ylab = "Centred effect"
-  ))
-  expect_invisible(plot(
-    ice,
-    type = "plate",
-    main = "Plate",
-    xlab = "Baseline",
-    ylab = "Slope",
-    pch = 1
   ))
 
   pred_to <- pred


### PR DESCRIPTION
## Summary

- remove the Plate slope helper, derivative API, original-case evaluation, slope values, and `plate` result data from `ice_mst_pmdn()`
- simplify `plot.mst_pmdn_ice()` to render centred ICE only
- update tests, manual pages, README, and NEWS to describe the retained ICE/ALE interface
- add no deprecation paths, compatibility shims, or legacy-call checks

## Rationale

Plate analysis is no longer part of the intended XAI surface. Removing its baseline-contrast and finite-difference machinery keeps ICE focused on centred case-level effects, reduces each ICE call by one model forward pass and one functional evaluation, and leaves ALE, image attribution, mixture attribution, latent draws, and parameter-channel decomposition unchanged.

## Validation

- R source and Rd parsing passed
- centred-ICE plotting smoke test passed
- `git diff --check` passed
- repository-wide search found no remaining Plate-specific symbols
- remote commit tree matches the reviewed local worktree exactly

Native `testthat` execution and `R CMD check` were not run because this environment has no R/torch runtime.