### PR TITLE
Improve XAI Monte Carlo diagnostics and occlusion stability

### DIFF
--- a/R/explain-channels.R
+++ b/R/explain-channels.R
@@ -25,6 +25,41 @@
   isTRUE(torch_equal(x$to(device = "cpu"), y$to(device = "cpu")))
 }
 
+.tensor_all_zero_mst_pmdn <- function(x) {
+  isTRUE((x == 0)$all()$item())
+}
+
+.effectively_symmetric_mst_pmdn <- function(pred, name) {
+  .validate_skew_none(pred, name) || .tensor_all_zero_mst_pmdn(pred$alpha)
+}
+
+.max_abs_tensor_change_mst_pmdn <- function(from, to, inverse = FALSE) {
+  from <- as.numeric(torch::as_array(from$to(device = "cpu")))
+  to <- as.numeric(torch::as_array(to$to(device = "cpu")))
+  if (isTRUE(inverse)) {
+    from <- 1 / from
+    to <- 1 / to
+  }
+  .max_abs_finite_mst_pmdn(to - from)
+}
+
+.channel_change_magnitudes_mst_pmdn <- function(pred_from, pred_to) {
+  c(
+    location = .max_abs_tensor_change_mst_pmdn(
+      pred_from$mu, pred_to$mu
+    ),
+    scale = .max_abs_tensor_change_mst_pmdn(
+      pred_from$scale_chol, pred_to$scale_chol
+    ),
+    skewness = .max_abs_tensor_change_mst_pmdn(
+      pred_from$alpha, pred_to$alpha
+    ),
+    df = .max_abs_tensor_change_mst_pmdn(
+      pred_from$nu, pred_to$nu, inverse = TRUE
+    )
+  )
+}
+
 .channel_is_active_mst_pmdn <- function(channel, pred_from, pred_to) {
   switch(
     channel,
@@ -33,10 +68,14 @@
       pred_from$scale_chol, pred_to$scale_chol
     ),
     skewness = {
-      from_none <- .validate_skew_none(pred_from, "pred_from")
-      to_none <- .validate_skew_none(pred_to, "pred_to")
-      !(from_none && to_none) &&
-        (!identical(from_none, to_none) ||
+      from_symmetric <- .effectively_symmetric_mst_pmdn(
+        pred_from, "pred_from"
+      )
+      to_symmetric <- .effectively_symmetric_mst_pmdn(
+        pred_to, "pred_to"
+      )
+      !(from_symmetric && to_symmetric) &&
+        (!identical(from_symmetric, to_symmetric) ||
          !.tensor_equal_mst_pmdn(pred_from$alpha, pred_to$alpha))
     },
     df = !.tensor_equal_mst_pmdn(pred_from$nu, pred_to$nu),
@@ -99,7 +138,8 @@ decompose_mst_pmdn <- function(pred_from,
                                seed = NULL,
                                chunk_size = NULL,
                                device = "cpu",
-                               response_names = NULL) {
+                               response_names = NULL,
+                               min_tail_draws = 20L) {
   from_info <- .validate_prediction_mst_pmdn(pred_from, "pred_from")
   to_info <- .validate_prediction_mst_pmdn(pred_to, "pred_to")
   if (!identical(from_info, to_info)) {
@@ -120,6 +160,7 @@ decompose_mst_pmdn <- function(pred_from,
     pred_to = pred_to
   )]
   num_samples <- validate_num_samples(num_samples)
+  min_tail_draws <- validate_num_samples(min_tail_draws)
   latent_draws <- .ensure_latent_bank_mst_pmdn(
     pred_from, functional, latent_draws, num_samples, seed, device
   )
@@ -143,7 +184,8 @@ decompose_mst_pmdn <- function(pred_from,
       latent_draws,
       chunk_size,
       device,
-      response_names
+      response_names,
+      min_tail_draws
     )
     state_values[state + 1L, ] <- result$data$value
     state_results[[state + 1L]] <- result$diagnostics
@@ -177,10 +219,11 @@ decompose_mst_pmdn <- function(pred_from,
   to_value <- state_values[n_states, ]
   total <- to_value - from_value
   residual <- total - rowSums(contributions)
-  state_tail_resolution <- vapply(
-    state_results,
-    function(x) x$min_expected_tail_draws,
-    numeric(1)
+  tail_summary <- .tail_resolution_summary_mst_pmdn(
+    state_results, min_tail_draws
+  )
+  .warn_tail_resolution_mst_pmdn(
+    tail_summary, "decompose_mst_pmdn()"
   )
   data <- data.frame(
     row = seq_len(from_info$batch_size),
@@ -204,14 +247,18 @@ decompose_mst_pmdn <- function(pred_from,
       num_samples = if (is.null(latent_draws)) NA_integer_ else
         latent_draws$num_samples,
       chunk_size = chunk_size,
-      device = device
+      device = device,
+      min_tail_draws = min_tail_draws
     ),
-    diagnostics = list(
-      max_abs_sum_to_total_residual = .max_abs_finite_mst_pmdn(residual),
-      min_expected_tail_draws = .min_finite_mst_pmdn(
-        state_tail_resolution
+    diagnostics = c(
+      list(
+        max_abs_sum_to_total_residual =
+          .max_abs_finite_mst_pmdn(residual),
+        parameter_change_magnitudes =
+          .channel_change_magnitudes_mst_pmdn(pred_from, pred_to),
+        state = state_results
       ),
-      state = state_results
+      tail_summary
     ),
     latent_draws = .latent_draws_for_output_mst_pmdn(latent_draws)
   )

--- a/R/explain-effects.R
+++ b/R/explain-effects.R
@@ -415,7 +415,6 @@ ice_mst_pmdn <- function(model,
                          grid = NULL,
                          reference = NULL,
                          n_curves = 100L,
-                         cases = NULL,
                          ale = TRUE,
                          n_bins = 20L,
                          num_samples = 4096L,
@@ -424,6 +423,7 @@ ice_mst_pmdn <- function(model,
                          chunk_size = NULL,
                          device = "cpu",
                          response_names = NULL,
+                         cases = NULL,
                          min_tail_draws = 20L) {
   if (!inherits(functional, "mst_functional")) {
     stop("functional must be returned by mst_functional().", call. = FALSE)

--- a/R/explain-effects.R
+++ b/R/explain-effects.R
@@ -143,15 +143,17 @@
                                                latent_draws,
                                                chunk_size,
                                                device,
-                                               response_names) {
-  suppressWarnings(functional_mst_pmdn(
+                                               response_names,
+                                               min_tail_draws) {
+  .muffle_tail_resolution_warnings_mst_pmdn(functional_mst_pmdn(
     pred = pred,
     functional = functional,
     num_samples = num_samples,
     latent_draws = latent_draws,
     chunk_size = chunk_size,
     device = device,
-    response_names = response_names
+    response_names = response_names,
+    min_tail_draws = min_tail_draws
   ))
 }
 
@@ -211,7 +213,8 @@ ale_mst_pmdn <- function(model,
                          seed = NULL,
                          chunk_size = NULL,
                          device = "cpu",
-                         response_names = NULL) {
+                         response_names = NULL,
+                         min_tail_draws = 20L) {
   if (!inherits(functional, "mst_functional")) {
     stop("functional must be returned by mst_functional().", call. = FALSE)
   }
@@ -219,6 +222,7 @@ ale_mst_pmdn <- function(model,
   feature_info <- .resolve_feature_mst_pmdn(feature, inputs_matrix)
   .validate_image_alignment_mst_pmdn(image_inputs, nrow(inputs_matrix))
   num_samples <- validate_num_samples(num_samples)
+  min_tail_draws <- validate_num_samples(min_tail_draws)
   if (isTRUE(decompose)) {
     probe <- .predict_chunks_mst_pmdn(
       model,
@@ -262,7 +266,8 @@ ale_mst_pmdn <- function(model,
     )
 
     if (isTRUE(decompose)) {
-      decomposition <- suppressWarnings(decompose_mst_pmdn(
+      decomposition <- .muffle_tail_resolution_warnings_mst_pmdn(
+        decompose_mst_pmdn(
         pred_from = pred_low,
         pred_to = pred_high,
         functional = functional,
@@ -272,7 +277,8 @@ ale_mst_pmdn <- function(model,
         num_samples = num_samples,
         chunk_size = chunk_size,
         device = device,
-        response_names = response_names
+        response_names = response_names,
+        min_tail_draws = min_tail_draws
       ))
       local_effect <- decomposition$data$total
       active_channels <- union(
@@ -283,28 +289,35 @@ ale_mst_pmdn <- function(model,
         function(channel) decomposition$data[[paste0("channel_", channel)]]
       )
       names(bin_channel_effects[[k]]) <- decomposition$active_channels
-      functional_diagnostics[[k]] <- list(
-        min_expected_tail_draws =
-          decomposition$diagnostics$min_expected_tail_draws,
-        decomposition = decomposition$diagnostics
+      functional_diagnostics[[k]] <- c(
+        list(decomposition = decomposition$diagnostics),
+        decomposition$diagnostics[c(
+          "min_expected_tail_draws",
+          "low_tail_resolution_count",
+          "tail_resolution_evaluations",
+          "low_tail_resolution_evaluations"
+        )]
       )
     } else {
       low <- .functional_values_quiet_mst_pmdn(
         pred_low, functional, num_samples, latent_draws,
-        chunk_size, device, response_names
+        chunk_size, device, response_names, min_tail_draws
       )
       high <- .functional_values_quiet_mst_pmdn(
         pred_high, functional, num_samples, latent_draws,
-        chunk_size, device, response_names
+        chunk_size, device, response_names, min_tail_draws
       )
       local_effect <- high$data$value - low$data$value
-      functional_diagnostics[[k]] <- list(
-        min_expected_tail_draws = .min_finite_mst_pmdn(c(
-          low$data$expected_tail_draws,
-          high$data$expected_tail_draws
-        )),
-        low = low$diagnostics,
-        high = high$diagnostics
+      bin_tail_summary <- .tail_resolution_summary_mst_pmdn(
+        list(low$diagnostics, high$diagnostics),
+        min_tail_draws
+      )
+      functional_diagnostics[[k]] <- c(
+        list(
+          low = low$diagnostics,
+          high = high$diagnostics
+        ),
+        bin_tail_summary
       )
     }
     bin_effect[k] <- mean(local_effect)
@@ -354,6 +367,12 @@ ale_mst_pmdn <- function(model,
   } else {
     rep(NA_real_, K)
   }
+  tail_summary <- .tail_resolution_summary_mst_pmdn(
+    functional_diagnostics, min_tail_draws
+  )
+  .warn_tail_resolution_mst_pmdn(
+    tail_summary, "ale_mst_pmdn()"
+  )
   out <- list(
     data = data,
     breaks = breaks,
@@ -366,19 +385,20 @@ ale_mst_pmdn <- function(model,
       num_samples = actual_samples,
       chunk_size = chunk_size,
       device = device,
-      decomposed = isTRUE(decompose)
+      decomposed = isTRUE(decompose),
+      min_tail_draws = min_tail_draws
     ),
-    diagnostics = list(
-      bin = functional_diagnostics,
-      min_expected_tail_draws_by_bin = minimum_tail_by_bin,
-      min_expected_tail_draws = .min_finite_mst_pmdn(
-        minimum_tail_by_bin
+    diagnostics = c(
+      list(
+        bin = functional_diagnostics,
+        min_expected_tail_draws_by_bin = minimum_tail_by_bin,
+        max_abs_sum_to_total_residual = if (length(active_channels)) {
+          .max_abs_finite_mst_pmdn(data$sum_to_total_residual)
+        } else {
+          NA_real_
+        }
       ),
-      max_abs_sum_to_total_residual = if (length(active_channels)) {
-        .max_abs_finite_mst_pmdn(data$sum_to_total_residual)
-      } else {
-        NA_real_
-      }
+      tail_summary
     ),
     latent_draws = .latent_draws_for_output_mst_pmdn(latent_draws)
   )
@@ -395,6 +415,7 @@ ice_mst_pmdn <- function(model,
                          grid = NULL,
                          reference = NULL,
                          n_curves = 100L,
+                         cases = NULL,
                          ale = TRUE,
                          n_bins = 20L,
                          num_samples = 4096L,
@@ -402,17 +423,25 @@ ice_mst_pmdn <- function(model,
                          seed = NULL,
                          chunk_size = NULL,
                          device = "cpu",
-                         response_names = NULL) {
+                         response_names = NULL,
+                         min_tail_draws = 20L) {
   if (!inherits(functional, "mst_functional")) {
     stop("functional must be returned by mst_functional().", call. = FALSE)
   }
   inputs_matrix <- .as_input_matrix_mst_pmdn(inputs)
   feature_info <- .resolve_feature_mst_pmdn(feature, inputs_matrix)
   .validate_image_alignment_mst_pmdn(image_inputs, nrow(inputs_matrix))
-  n_curves <- min(validate_num_samples(n_curves), nrow(inputs_matrix))
-  case_rows <- unique(as.integer(round(seq(
-    1, nrow(inputs_matrix), length.out = n_curves
-  ))))
+  if (is.null(cases)) {
+    n_curves <- min(validate_num_samples(n_curves), nrow(inputs_matrix))
+    case_rows <- unique(as.integer(round(seq(
+      1, nrow(inputs_matrix), length.out = n_curves
+    ))))
+    case_selection <- "systematic"
+  } else {
+    case_rows <- .validate_cases_mst_pmdn(cases, nrow(inputs_matrix))
+    n_curves <- length(case_rows)
+    case_selection <- "explicit"
+  }
   feature_values <- inputs_matrix[, feature_info$index]
   if (is.null(grid)) {
     grid <- unique(as.numeric(stats::quantile(
@@ -436,6 +465,7 @@ ice_mst_pmdn <- function(model,
     stop("reference must be one finite feature value.", call. = FALSE)
   }
   num_samples <- validate_num_samples(num_samples)
+  min_tail_draws <- validate_num_samples(min_tail_draws)
 
   selected_inputs <- inputs_matrix[case_rows, , drop = FALSE]
   selected_images <- .subset_rows_mst_pmdn(image_inputs, case_rows)
@@ -450,7 +480,7 @@ ice_mst_pmdn <- function(model,
   )
   reference_result <- .functional_values_quiet_mst_pmdn(
     pred_reference, functional, num_samples, latent_draws,
-    chunk_size, device, response_names
+    chunk_size, device, response_names, min_tail_draws
   )
   reference_values <- reference_result$data$value
 
@@ -465,7 +495,7 @@ ice_mst_pmdn <- function(model,
     )
     result <- .functional_values_quiet_mst_pmdn(
       pred_grid, functional, num_samples, latent_draws,
-      chunk_size, device, response_names
+      chunk_size, device, response_names, min_tail_draws
     )
     values[, g] <- result$data$value
     grid_diagnostics[[g]] <- result$diagnostics
@@ -489,7 +519,8 @@ ice_mst_pmdn <- function(model,
     ale_result <- ale
     ale_mode <- "supplied"
   } else if (isTRUE(ale)) {
-    ale_result <- ale_mst_pmdn(
+    ale_result <- .muffle_tail_resolution_warnings_mst_pmdn(
+      ale_mst_pmdn(
       model = model,
       inputs = inputs_matrix,
       image_inputs = image_inputs,
@@ -501,8 +532,9 @@ ice_mst_pmdn <- function(model,
       latent_draws = latent_draws,
       chunk_size = chunk_size,
       device = device,
-      response_names = response_names
-    )
+      response_names = response_names,
+      min_tail_draws = min_tail_draws
+    ))
     ale_mode <- "computed"
   } else if (identical(ale, FALSE) || is.null(ale)) {
     ale_result <- NULL
@@ -512,6 +544,19 @@ ice_mst_pmdn <- function(model,
          call. = FALSE)
   }
 
+  tail_diagnostics <- c(
+    list(reference_result$diagnostics),
+    grid_diagnostics
+  )
+  if (identical(ale_mode, "computed")) {
+    tail_diagnostics <- c(tail_diagnostics, list(ale_result$diagnostics))
+  }
+  tail_summary <- .tail_resolution_summary_mst_pmdn(
+    tail_diagnostics, min_tail_draws
+  )
+  .warn_tail_resolution_mst_pmdn(
+    tail_summary, "ice_mst_pmdn()"
+  )
   out <- list(
     curves = curves,
     ale = ale_result,
@@ -525,11 +570,21 @@ ice_mst_pmdn <- function(model,
       num_samples = if (is.null(latent_draws)) NA_integer_ else
         latent_draws$num_samples,
       chunk_size = chunk_size,
-      device = device
+      device = device,
+      case_selection = case_selection,
+      min_tail_draws = min_tail_draws
     ),
-    diagnostics = list(
-      reference = reference_result$diagnostics,
-      grid = grid_diagnostics
+    diagnostics = c(
+      list(
+        reference = reference_result$diagnostics,
+        grid = grid_diagnostics,
+        ale = if (identical(ale_mode, "computed")) {
+          ale_result$diagnostics
+        } else {
+          NULL
+        }
+      ),
+      tail_summary
     ),
     latent_draws = .latent_draws_for_output_mst_pmdn(latent_draws)
   )

--- a/R/explain-images.R
+++ b/R/explain-images.R
@@ -190,6 +190,77 @@
   )
 }
 
+.normalize_latent_banks_mst_pmdn <- function(pred,
+                                               functional,
+                                               latent_draws,
+                                               num_samples,
+                                               seed,
+                                               device) {
+  if (!.functional_is_monte_carlo_mst_pmdn(functional$type)) {
+    return(list(NULL))
+  }
+  banks <- if (is.null(latent_draws) ||
+               inherits(latent_draws, "mst_pmdn_latent_draws")) {
+    list(latent_draws)
+  } else if (is.list(latent_draws) && length(latent_draws) &&
+             all(vapply(
+               latent_draws,
+               inherits,
+               logical(1),
+               what = "mst_pmdn_latent_draws"
+             ))) {
+    latent_draws
+  } else {
+    stop(
+      paste0(
+        "latent_draws must be a latent bank or a non-empty list of latent ",
+        "banks for image occlusion."
+      ),
+      call. = FALSE
+    )
+  }
+  banks <- lapply(banks, function(bank) {
+    .ensure_latent_bank_mst_pmdn(
+      pred, functional, bank, num_samples, seed, device
+    )
+  })
+  bank_samples <- vapply(banks, function(bank) {
+    bank$num_samples
+  }, integer(1))
+  if (length(unique(bank_samples)) != 1L) {
+    stop("Replicate latent banks must contain the same number of draws.",
+         call. = FALSE)
+  }
+  banks
+}
+
+.latent_banks_for_output_mst_pmdn <- function(banks) {
+  banks <- lapply(banks, .latent_draws_for_output_mst_pmdn)
+  if (length(banks) == 1L) banks[[1L]] else banks
+}
+
+.mc_effect_summary_mst_pmdn <- function(values) {
+  values <- as.matrix(values)
+  replicate_count <- ncol(values)
+  minimum <- apply(values, 1L, min)
+  maximum <- apply(values, 1L, max)
+  list(
+    effect = rowMeans(values),
+    mc_effect_sd = if (replicate_count > 1L) {
+      apply(values, 1L, stats::sd)
+    } else {
+      rep(NA_real_, nrow(values))
+    },
+    mc_effect_min = minimum,
+    mc_effect_max = maximum,
+    mc_sign_stable = if (replicate_count > 1L) {
+      (minimum > 0 & maximum > 0) | (minimum < 0 & maximum < 0)
+    } else {
+      rep(NA, nrow(values))
+    }
+  )
+}
+
 .normalize_channel_groups_mst_pmdn <- function(channel_groups, n_channels) {
   if (is.null(channel_groups)) {
     return(list(all = NULL))
@@ -238,7 +309,8 @@ image_contrast_mst_pmdn <- function(model,
                                     seed = NULL,
                                     chunk_size = NULL,
                                     device = "cpu",
-                                    response_names = NULL) {
+                                    response_names = NULL,
+                                    min_tail_draws = 20L) {
   if (!inherits(functional, "mst_functional")) {
     stop("functional must be returned by mst_functional().", call. = FALSE)
   }
@@ -290,6 +362,7 @@ image_contrast_mst_pmdn <- function(model,
     chunk_size = chunk_size, device = device
   )
   num_samples <- validate_num_samples(num_samples)
+  min_tail_draws <- validate_num_samples(min_tail_draws)
   latent_draws <- .ensure_latent_bank_mst_pmdn(
     pred_original, functional, latent_draws, num_samples, seed, device
   )
@@ -297,7 +370,8 @@ image_contrast_mst_pmdn <- function(model,
 
   active_channels <- character(0)
   if (isTRUE(decompose)) {
-    decomposition <- suppressWarnings(decompose_mst_pmdn(
+    decomposition <- .muffle_tail_resolution_warnings_mst_pmdn(
+      decompose_mst_pmdn(
       pred_from = pred_reference,
       pred_to = pred_original,
       functional = functional,
@@ -306,7 +380,8 @@ image_contrast_mst_pmdn <- function(model,
       num_samples = num_samples,
       chunk_size = chunk_size,
       device = device,
-      response_names = response_names
+      response_names = response_names,
+      min_tail_draws = min_tail_draws
     ))
     data <- data.frame(
       case = cases,
@@ -325,11 +400,11 @@ image_contrast_mst_pmdn <- function(model,
   } else {
     original_result <- .functional_values_quiet_mst_pmdn(
       pred_original, functional, num_samples, latent_draws,
-      chunk_size, device, response_names
+      chunk_size, device, response_names, min_tail_draws
     )
     reference_result <- .functional_values_quiet_mst_pmdn(
       pred_reference, functional, num_samples, latent_draws,
-      chunk_size, device, response_names
+      chunk_size, device, response_names, min_tail_draws
     )
     data <- data.frame(
       case = cases,
@@ -338,11 +413,29 @@ image_contrast_mst_pmdn <- function(model,
       contrast = original_result$data$value - reference_result$data$value,
       sum_to_total_residual = NA_real_
     )
-    diagnostics <- list(
-      original = original_result$diagnostics,
-      reference = reference_result$diagnostics
+    tail_summary <- .tail_resolution_summary_mst_pmdn(
+      list(original_result$diagnostics, reference_result$diagnostics),
+      min_tail_draws
+    )
+    diagnostics <- c(
+      list(
+        original = original_result$diagnostics,
+        reference = reference_result$diagnostics
+      ),
+      tail_summary
     )
   }
+  if (isTRUE(decompose)) {
+    tail_summary <- diagnostics[c(
+      "min_expected_tail_draws",
+      "low_tail_resolution_count",
+      "tail_resolution_evaluations",
+      "low_tail_resolution_evaluations"
+    )]
+  }
+  .warn_tail_resolution_mst_pmdn(
+    tail_summary, "image_contrast_mst_pmdn()"
+  )
   out <- list(
     data = data,
     functional = functional,
@@ -354,7 +447,8 @@ image_contrast_mst_pmdn <- function(model,
       num_samples = if (is.null(latent_draws)) NA_integer_ else
         latent_draws$num_samples,
       chunk_size = chunk_size,
-      device = device
+      device = device,
+      min_tail_draws = min_tail_draws
     ),
     diagnostics = diagnostics,
     latent_draws = .latent_draws_for_output_mst_pmdn(latent_draws)
@@ -422,7 +516,8 @@ image_occlusion_mst_pmdn <- function(model,
                                      seed = NULL,
                                      chunk_size = NULL,
                                      device = "cpu",
-                                     response_names = NULL) {
+                                     response_names = NULL,
+                                     min_tail_draws = 20L) {
   if (!inherits(functional, "mst_functional")) {
     stop("functional must be returned by mst_functional().", call. = FALSE)
   }
@@ -440,6 +535,7 @@ image_occlusion_mst_pmdn <- function(model,
   reference_images <- .coerce_reference_images_like_mst_pmdn(
     reference_images, image_inputs
   )
+  grouped_channels <- !is.null(channel_groups)
   groups <- .normalize_channel_groups_mst_pmdn(
     channel_groups, image_shape[2]
   )
@@ -454,11 +550,16 @@ image_occlusion_mst_pmdn <- function(model,
   reference <- .subset_rows_mst_pmdn(reference_images, cases)
   n <- length(cases)
   num_samples <- validate_num_samples(num_samples)
+  min_tail_draws <- validate_num_samples(min_tail_draws)
 
   original_images <- .rebuild_or_blend_images_mst_pmdn(
     base,
     reference,
-    .zero_mask_mst_pmdn(base, n),
+    .zero_mask_mst_pmdn(
+      base,
+      n,
+      channels = if (grouped_channels) seq_len(image_shape[2]) else NULL
+    ),
     rebuild_channels,
     cases
   )
@@ -469,14 +570,24 @@ image_occlusion_mst_pmdn <- function(model,
   if (isTRUE(decompose)) {
     .require_single_component_mst_pmdn(pred_original)
   }
-  latent_draws <- .ensure_latent_bank_mst_pmdn(
-    pred_original, functional, latent_draws, num_samples, seed, device
+  latent_banks <- .normalize_latent_banks_mst_pmdn(
+    pred_original,
+    functional,
+    latent_draws,
+    num_samples,
+    seed,
+    device
   )
-  if (!is.null(latent_draws)) num_samples <- latent_draws$num_samples
-  original_result <- .functional_values_quiet_mst_pmdn(
-    pred_original, functional, num_samples, latent_draws,
-    chunk_size, device, response_names
-  )
+  replicate_count <- length(latent_banks)
+  if (!is.null(latent_banks[[1L]])) {
+    num_samples <- latent_banks[[1L]]$num_samples
+  }
+  original_results <- lapply(latent_banks, function(bank) {
+    .functional_values_quiet_mst_pmdn(
+      pred_original, functional, num_samples, bank,
+      chunk_size, device, response_names, min_tail_draws
+    )
+  })
 
   row_starts <- .patch_starts_mst_pmdn(
     image_shape[3], patch_size[1], stride[1]
@@ -494,8 +605,15 @@ image_occlusion_mst_pmdn <- function(model,
   patch_table$col_end <- patch_table$col_start + patch_size[2] - 1L
   patch_table$row_center <- (patch_table$row_start + patch_table$row_end) / 2
   patch_table$col_center <- (patch_table$col_start + patch_table$col_end) / 2
+  patch_table$mask_sum <- NA_real_
+  patch_table$mask_mean <- NA_real_
+  patch_table$mask_max <- NA_real_
   coverage <- matrix(0, nrow = image_shape[3], ncol = image_shape[4])
+  weighted_coverage <- matrix(
+    0, nrow = image_shape[3], ncol = image_shape[4]
+  )
   rows_out <- list()
+  replicate_rows_out <- list()
   active_channels <- character(0)
   diagnostics <- list()
   output_index <- 0L
@@ -508,7 +626,13 @@ image_occlusion_mst_pmdn <- function(model,
       patch_size,
       taper
     )
+    patch_weights <- patch_mask[patch_mask > 0]
+    patch_table$mask_sum[patch_row] <- sum(patch_weights)
+    patch_table$mask_mean[patch_row] <- mean(patch_weights)
+    patch_table$mask_max[patch_row] <- max(patch_weights)
     coverage <- coverage + (patch_mask > 0)
+    weighted_coverage <- weighted_coverage + patch_mask
+
     for (group_name in names(groups)) {
       group <- groups[[group_name]]
       masks <- .mask_like_images_mst_pmdn(
@@ -522,37 +646,87 @@ image_occlusion_mst_pmdn <- function(model,
         original_images,
         "rebuilt occluded images"
       )
+      # The model prediction is independent of the latent bank and is retained
+      # for every replicate evaluation below.
       pred_occluded <- .predict_chunks_mst_pmdn(
         model, case_inputs, occluded_images,
         chunk_size = chunk_size, device = device
       )
 
+      channel_matrices <- list()
       if (isTRUE(decompose)) {
-        decomposition <- suppressWarnings(decompose_mst_pmdn(
-          pred_from = pred_occluded,
-          pred_to = pred_original,
-          functional = functional,
-          channels = channels,
-          latent_draws = latent_draws,
-          num_samples = num_samples,
-          chunk_size = chunk_size,
-          device = device,
-          response_names = response_names
+        replicate_results <- lapply(latent_banks, function(bank) {
+          .muffle_tail_resolution_warnings_mst_pmdn(
+            decompose_mst_pmdn(
+              pred_from = pred_occluded,
+              pred_to = pred_original,
+              functional = functional,
+              channels = channels,
+              latent_draws = bank,
+              num_samples = num_samples,
+              chunk_size = chunk_size,
+              device = device,
+              response_names = response_names,
+              min_tail_draws = min_tail_draws
+            )
+          )
+        })
+        effect_values <- do.call(cbind, lapply(
+          replicate_results, function(result) result$data$total
         ))
-        effect <- decomposition$data$total
-        active_channels <- union(
-          active_channels, decomposition$active_channels
+        patch_active <- Reduce(
+          union,
+          lapply(replicate_results, function(result) {
+            result$active_channels
+          }),
+          init = character(0)
         )
-        diagnostic <- decomposition$diagnostics
+        active_channels <- union(active_channels, patch_active)
+        for (channel in requested_channels) {
+          column <- paste0("channel_", channel)
+          channel_matrices[[channel]] <- do.call(cbind, lapply(
+            replicate_results,
+            function(result) {
+              if (channel %in% result$active_channels) {
+                result$data[[column]]
+              } else {
+                rep(0, n)
+              }
+            }
+          ))
+        }
+        replicate_diagnostics <- lapply(
+          replicate_results, function(result) result$diagnostics
+        )
       } else {
-        occluded_result <- .functional_values_quiet_mst_pmdn(
-          pred_occluded, functional, num_samples, latent_draws,
-          chunk_size, device, response_names
+        replicate_results <- lapply(
+          seq_along(latent_banks),
+          function(replicate) {
+            .functional_values_quiet_mst_pmdn(
+              pred_occluded,
+              functional,
+              num_samples,
+              latent_banks[[replicate]],
+              chunk_size,
+              device,
+              response_names,
+              min_tail_draws
+            )
+          }
         )
-        effect <- original_result$data$value - occluded_result$data$value
-        diagnostic <- occluded_result$diagnostics
+        effect_values <- do.call(cbind, lapply(
+          seq_along(replicate_results),
+          function(replicate) {
+            original_results[[replicate]]$data$value -
+              replicate_results[[replicate]]$data$value
+          }
+        ))
+        replicate_diagnostics <- lapply(
+          replicate_results, function(result) result$diagnostics
+        )
       }
 
+      effect_summary <- .mc_effect_summary_mst_pmdn(effect_values)
       output_index <- output_index + 1L
       block <- data.frame(
         case = cases,
@@ -564,61 +738,166 @@ image_occlusion_mst_pmdn <- function(model,
         col_end = patch_table$col_end[patch_row],
         row_center = patch_table$row_center[patch_row],
         col_center = patch_table$col_center[patch_row],
-        effect = effect
+        effect = effect_summary$effect,
+        mc_effect_sd = effect_summary$mc_effect_sd,
+        mc_effect_min = effect_summary$mc_effect_min,
+        mc_effect_max = effect_summary$mc_effect_max,
+        mc_sign_stable = effect_summary$mc_sign_stable,
+        mc_replicates = replicate_count
       )
       if (isTRUE(decompose)) {
         for (channel in requested_channels) {
-          column <- paste0("channel_", channel)
-          block[[column]] <- if (channel %in% decomposition$active_channels) {
-            decomposition$data[[column]]
-          } else {
-            0
-          }
+          block[[paste0("channel_", channel)]] <-
+            rowMeans(channel_matrices[[channel]])
         }
-        block$sum_to_total_residual <-
-          decomposition$data$sum_to_total_residual
+        block$sum_to_total_residual <- block$effect - rowSums(
+          block[paste0("channel_", requested_channels)]
+        )
       } else {
         block$sum_to_total_residual <- NA_real_
       }
       rows_out[[output_index]] <- block
-      diagnostics[[output_index]] <- diagnostic
+
+      replicate_block <- do.call(rbind, lapply(
+        seq_len(replicate_count),
+        function(replicate) {
+          item <- data.frame(
+            case = cases,
+            group = group_name,
+            patch = patch_table$patch[patch_row],
+            row_center = patch_table$row_center[patch_row],
+            col_center = patch_table$col_center[patch_row],
+            replicate = replicate,
+            effect = effect_values[, replicate]
+          )
+          if (isTRUE(decompose)) {
+            for (channel in requested_channels) {
+              item[[paste0("channel_", channel)]] <-
+                channel_matrices[[channel]][, replicate]
+            }
+            item$sum_to_total_residual <- item$effect - rowSums(
+              item[paste0("channel_", requested_channels)]
+            )
+          } else {
+            item$sum_to_total_residual <- NA_real_
+          }
+          item
+        }
+      ))
+      rownames(replicate_block) <- NULL
+      replicate_rows_out[[output_index]] <- replicate_block
+      diagnostics[[output_index]] <- c(
+        list(replicate = replicate_diagnostics),
+        .tail_resolution_summary_mst_pmdn(
+          replicate_diagnostics, min_tail_draws
+        )
+      )
     }
   }
+
   data <- do.call(rbind, rows_out)
+  replicate_data <- do.call(rbind, replicate_rows_out)
   rownames(data) <- NULL
-  for (channel in active_channels) {
-    column <- paste0("channel_", channel)
-    if (!column %in% names(data)) data[[column]] <- 0
-    data[[column]][is.na(data[[column]])] <- 0
-  }
+  rownames(replicate_data) <- NULL
   inactive_channels <- setdiff(requested_channels, active_channels)
   if (length(inactive_channels)) {
     data[paste0("channel_", inactive_channels)] <- NULL
+    replicate_data[paste0("channel_", inactive_channels)] <- NULL
   }
   if (length(active_channels)) {
     data$sum_to_total_residual <- data$effect - rowSums(
       data[paste0("channel_", active_channels)]
     )
+    replicate_data$sum_to_total_residual <-
+      replicate_data$effect - rowSums(
+        replicate_data[paste0("channel_", active_channels)]
+      )
   }
-  population <- do.call(rbind, lapply(
-    split(data, list(data$group, data$patch), drop = TRUE),
+
+  population_replicate <- do.call(rbind, lapply(
+    split(
+      replicate_data,
+      list(
+        replicate_data$group,
+        replicate_data$patch,
+        replicate_data$replicate
+      ),
+      drop = TRUE
+    ),
     function(block) data.frame(
       group = block$group[1L],
       patch = block$patch[1L],
       row_center = block$row_center[1L],
       col_center = block$col_center[1L],
-      mean_signed_effect = mean(block$effect),
-      mean_absolute_effect = mean(abs(block$effect)),
-      positive_fraction = mean(block$effect > 0)
+      replicate = block$replicate[1L],
+      mean_signed_effect = mean(block$effect)
     )
+  ))
+  rownames(population_replicate) <- NULL
+  population <- do.call(rbind, lapply(
+    split(data, list(data$group, data$patch), drop = TRUE),
+    function(block) {
+      replicate_block <- population_replicate[
+        population_replicate$group == block$group[1L] &
+          population_replicate$patch == block$patch[1L],
+        ,
+        drop = FALSE
+      ]
+      mc_summary <- .mc_effect_summary_mst_pmdn(matrix(
+        replicate_block$mean_signed_effect,
+        nrow = 1L
+      ))
+      data.frame(
+        group = block$group[1L],
+        patch = block$patch[1L],
+        row_center = block$row_center[1L],
+        col_center = block$col_center[1L],
+        mean_signed_effect = mean(block$effect),
+        mean_absolute_effect = mean(abs(block$effect)),
+        positive_fraction = mean(block$effect > 0),
+        mc_mean_signed_effect_sd = mc_summary$mc_effect_sd,
+        mc_mean_signed_effect_min = mc_summary$mc_effect_min,
+        mc_mean_signed_effect_max = mc_summary$mc_effect_max,
+        mc_mean_signed_effect_sign_stable = mc_summary$mc_sign_stable,
+        mc_replicates = replicate_count
+      )
+    }
   ))
   rownames(population) <- NULL
 
+  original_diagnostics <- lapply(
+    original_results, function(result) result$diagnostics
+  )
+  tail_summary <- .tail_resolution_summary_mst_pmdn(
+    c(original_diagnostics, diagnostics),
+    min_tail_draws
+  )
+  .warn_tail_resolution_mst_pmdn(
+    tail_summary, "image_occlusion_mst_pmdn()"
+  )
+  minimum_tail_by_evaluation <- c(
+    vapply(
+      original_diagnostics,
+      function(item) item$min_expected_tail_draws,
+      numeric(1)
+    ),
+    unlist(lapply(diagnostics, function(item) {
+      vapply(
+        item$replicate,
+        function(replicate) replicate$min_expected_tail_draws,
+        numeric(1)
+      )
+    }), use.names = FALSE)
+  )
+
   out <- list(
     data = data,
+    replicate_data = replicate_data,
     population = population,
+    population_replicate = population_replicate,
     patches = patch_table,
     coverage = coverage,
+    weighted_coverage = weighted_coverage,
     functional = functional,
     cases = cases,
     channel_groups = groups,
@@ -629,21 +908,35 @@ image_occlusion_mst_pmdn <- function(model,
       taper = taper,
       decomposed = isTRUE(decompose),
       rebuild_channels = !is.null(rebuild_channels),
-      num_samples = if (is.null(latent_draws)) NA_integer_ else
-        latent_draws$num_samples,
-      chunk_size = chunk_size,
-      device = device
-    ),
-    diagnostics = list(
-      original = original_result$diagnostics,
-      occluded = diagnostics,
-      max_abs_sum_to_total_residual = if (length(active_channels)) {
-        .max_abs_finite_mst_pmdn(data$sum_to_total_residual)
+      num_samples = if (is.null(latent_banks[[1L]])) {
+        NA_integer_
       } else {
-        NA_real_
-      }
+        latent_banks[[1L]]$num_samples
+      },
+      mc_replicates = replicate_count,
+      chunk_size = chunk_size,
+      device = device,
+      min_tail_draws = min_tail_draws
     ),
-    latent_draws = .latent_draws_for_output_mst_pmdn(latent_draws)
+    diagnostics = c(
+      list(
+        original = if (replicate_count == 1L) {
+          original_diagnostics[[1L]]
+        } else {
+          original_diagnostics
+        },
+        occluded = diagnostics,
+        min_expected_tail_draws_by_evaluation =
+          minimum_tail_by_evaluation,
+        max_abs_sum_to_total_residual = if (length(active_channels)) {
+          .max_abs_finite_mst_pmdn(data$sum_to_total_residual)
+        } else {
+          NA_real_
+        }
+      ),
+      tail_summary
+    ),
+    latent_draws = .latent_banks_for_output_mst_pmdn(latent_banks)
   )
   class(out) <- "mst_pmdn_image_occlusion"
   out
@@ -668,6 +961,7 @@ print.mst_pmdn_image_occlusion <- function(x, ...) {
     "  cases: ", length(x$cases), "\n",
     "  patches: ", nrow(x$patches), "\n",
     "  channel groups: ", length(x$channel_groups), "\n",
+    "  Monte Carlo replicates: ", x$settings$mc_replicates, "\n",
     "  decomposed: ", x$settings$decomposed, "\n",
     sep = ""
   )

--- a/R/explain-mixtures.R
+++ b/R/explain-mixtures.R
@@ -27,6 +27,7 @@
     alpha = torch_index_select(pred$alpha, 2L, index_for(pred$alpha)),
     skew_none = .validate_skew_none(pred, "pred")
   )
+  attr(out, "response_names") <- attr(pred, "response_names")
   out
 }
 
@@ -69,7 +70,8 @@ tail_components_mst_pmdn <- function(pred,
       latent_draws,
       chunk_size,
       device,
-      response_names
+      response_names,
+      min_tail_draws
     )
     component_probability[, component] <- result$data$value
     component_diagnostics[[component]] <- result$diagnostics
@@ -90,19 +92,20 @@ tail_components_mst_pmdn <- function(pred,
   }
   expected_tail_draws <- num_samples * pmin(total, 1 - total)
   low_resolution <- expected_tail_draws < min_tail_draws
-  if (any(low_resolution)) {
-    warning(
-      sprintf(
-        paste0(
-          "Mixture exceedance resolution is below %d expected draws for %d ",
-          "prediction row(s)."
-        ),
-        min_tail_draws,
-        sum(low_resolution)
-      ),
-      call. = FALSE
-    )
-  }
+  total_diagnostics <- list(
+    min_expected_tail_draws =
+      .min_finite_mst_pmdn(expected_tail_draws),
+    low_tail_resolution_count = sum(low_resolution),
+    tail_resolution_evaluations = 1L,
+    low_tail_resolution_evaluations = as.integer(any(low_resolution))
+  )
+  tail_summary <- .tail_resolution_summary_mst_pmdn(
+    c(component_diagnostics, list(total_diagnostics)),
+    min_tail_draws
+  )
+  .warn_tail_resolution_mst_pmdn(
+    tail_summary, "tail_components_mst_pmdn()"
+  )
 
   data <- do.call(rbind, lapply(seq_len(info$batch_size), function(row) {
     data.frame(
@@ -128,12 +131,12 @@ tail_components_mst_pmdn <- function(pred,
       device = device,
       min_tail_draws = min_tail_draws
     ),
-    diagnostics = list(
-      component = component_diagnostics,
-      low_tail_resolution_rows = which(low_resolution),
-      min_expected_tail_draws = .min_finite_mst_pmdn(
-        expected_tail_draws
-      )
+    diagnostics = c(
+      list(
+        component = component_diagnostics,
+        low_tail_resolution_rows = which(low_resolution)
+      ),
+      tail_summary
     ),
     latent_draws = .latent_draws_for_output_mst_pmdn(latent_draws)
   )

--- a/R/functionals.R
+++ b/R/functionals.R
@@ -381,6 +381,103 @@ print.mst_functional <- function(x, ...) {
   if (length(x)) max(x) else NA_real_
 }
 
+.tail_resolution_summary_mst_pmdn <- function(diagnostics,
+                                                min_tail_draws) {
+  if (is.null(diagnostics)) diagnostics <- list()
+  if (!is.list(diagnostics)) {
+    stop("diagnostics must be a list.", call. = FALSE)
+  }
+  if (!is.null(diagnostics$min_expected_tail_draws)) {
+    diagnostics <- list(diagnostics)
+  }
+  diagnostics <- Filter(Negate(is.null), diagnostics)
+
+  minimum <- vapply(diagnostics, function(item) {
+    value <- item$min_expected_tail_draws
+    if (is.null(value) || !length(value)) NA_real_ else as.numeric(value[1L])
+  }, numeric(1))
+  low_count <- vapply(diagnostics, function(item) {
+    if (!is.null(item$low_tail_resolution_count)) {
+      return(as.integer(item$low_tail_resolution_count))
+    }
+    as.integer(length(item$low_tail_resolution_rows))
+  }, integer(1))
+  evaluations <- vapply(diagnostics, function(item) {
+    if (!is.null(item$tail_resolution_evaluations)) {
+      return(as.integer(item$tail_resolution_evaluations))
+    }
+    value <- item$min_expected_tail_draws
+    as.integer(length(value) && is.finite(value[1L]))
+  }, integer(1))
+  affected <- vapply(diagnostics, function(item) {
+    if (!is.null(item$low_tail_resolution_evaluations)) {
+      return(as.integer(item$low_tail_resolution_evaluations))
+    }
+    as.integer(
+      (!is.null(item$low_tail_resolution_count) &&
+       item$low_tail_resolution_count > 0L) ||
+      length(item$low_tail_resolution_rows) > 0L
+    )
+  }, integer(1))
+
+  list(
+    min_tail_draws = as.integer(min_tail_draws),
+    min_expected_tail_draws = .min_finite_mst_pmdn(minimum),
+    low_tail_resolution_count = sum(low_count),
+    tail_resolution_evaluations = sum(evaluations),
+    low_tail_resolution_evaluations = sum(affected)
+  )
+}
+
+.warn_tail_resolution_mst_pmdn <- function(summary, context) {
+  if (is.null(summary$low_tail_resolution_count) ||
+      summary$low_tail_resolution_count < 1L) {
+    return(invisible(FALSE))
+  }
+  condition <- structure(
+    list(
+      message = sprintf(
+        paste0(
+          "%s: Monte Carlo tail resolution is below %d expected draws for ",
+          "%d evaluated prediction row(s) across %d of %d functional ",
+          "evaluation(s); minimum expected draws = %s. Increase num_samples ",
+          "or inspect diagnostics."
+        ),
+        context,
+        summary$min_tail_draws,
+        summary$low_tail_resolution_count,
+        summary$low_tail_resolution_evaluations,
+        summary$tail_resolution_evaluations,
+        format(summary$min_expected_tail_draws, digits = 5)
+      ),
+      call = NULL,
+      min_tail_draws = summary$min_tail_draws,
+      min_expected_tail_draws = summary$min_expected_tail_draws,
+      low_tail_resolution_count = summary$low_tail_resolution_count,
+      tail_resolution_evaluations = summary$tail_resolution_evaluations,
+      low_tail_resolution_evaluations =
+        summary$low_tail_resolution_evaluations,
+      context = context
+    ),
+    class = c(
+      "mst_pmdn_tail_resolution_warning",
+      "warning",
+      "condition"
+    )
+  )
+  warning(condition)
+  invisible(TRUE)
+}
+
+.muffle_tail_resolution_warnings_mst_pmdn <- function(expr) {
+  withCallingHandlers(
+    expr,
+    mst_pmdn_tail_resolution_warning = function(condition) {
+      invokeRestart("muffleWarning")
+    }
+  )
+}
+
 .analytic_functional_mst_pmdn <- function(pred, functional, responses) {
   type <- functional$type
   info <- .validate_prediction_mst_pmdn(pred)
@@ -646,19 +743,23 @@ functional_mst_pmdn <- function(pred,
   } else {
     NULL
   }
-  if (any(low_resolution)) {
-    warning(
-      sprintf(
-        paste0(
-          "Monte Carlo tail resolution is below %d expected draws for %d ",
-          "prediction row(s); increase num_samples or inspect diagnostics."
-        ),
-        min_tail_draws,
-        sum(low_resolution)
-      ),
-      call. = FALSE
-    )
-  }
+  tail_summary <- .tail_resolution_summary_mst_pmdn(
+    list(list(
+      min_expected_tail_draws = if (is_mc) {
+        .min_finite_mst_pmdn(expected_tail_draws)
+      } else {
+        NA_real_
+      },
+      low_tail_resolution_count = sum(low_resolution),
+      tail_resolution_evaluations = as.integer(is_mc),
+      low_tail_resolution_evaluations =
+        as.integer(is_mc && any(low_resolution))
+    )),
+    min_tail_draws
+  )
+  .warn_tail_resolution_mst_pmdn(
+    tail_summary, "functional_mst_pmdn()"
+  )
   invalid_analytic <- is.na(values) |
     (!is.finite(values) & functional$type != "df")
   if (!is_mc && any(invalid_analytic)) {
@@ -684,20 +785,20 @@ functional_mst_pmdn <- function(pred,
       device = device,
       min_tail_draws = min_tail_draws
     ),
-    diagnostics = list(
-      low_tail_resolution_rows = which(low_resolution),
-      min_expected_tail_draws = if (is_mc) {
-        .min_finite_mst_pmdn(expected_tail_draws)
-      } else {
-        NA_real_
-      },
-      expected_component_draws = expected_component_draws,
-      min_expected_component_draws = if (is.null(expected_component_draws)) {
-        NA_real_
-      } else {
-        min(expected_component_draws)
-      },
-      component_draws_shared_across_rows = is_mc && info$n_mixtures > 1L
+    diagnostics = c(
+      list(
+        low_tail_resolution_rows = which(low_resolution),
+        expected_component_draws = expected_component_draws,
+        min_expected_component_draws =
+          if (is.null(expected_component_draws)) {
+            NA_real_
+          } else {
+            min(expected_component_draws)
+          },
+        component_draws_shared_across_rows =
+          is_mc && info$n_mixtures > 1L
+      ),
+      tail_summary
     ),
     latent_draws = if (is_mc) {
       .latent_draws_for_output_mst_pmdn(latent_draws)

--- a/R/latent-draws.R
+++ b/R/latent-draws.R
@@ -152,10 +152,26 @@ latent_draws_mst_pmdn <- function(num_samples = 4096L,
     to(dtype = torch_long())
 }
 
+.uniform_probability_bounds_mst_pmdn <- function(dtype) {
+  if (dtype == torch_float()) {
+    return(c(lower = 2^-25, upper = 1 - 2^-25))
+  }
+  # The lower midpoint is half a double-precision uniform quantum. The upper
+  # bound uses the largest representable double below one.
+  c(lower = 2^-54, upper = 1 - 2^-53)
+}
+
+.cache_key_elements_mst_pmdn <- function(key) {
+  if (is.null(key)) return(0L)
+  sum(vapply(key, length, integer(1)))
+}
+
 .gamma_scale_from_uniform_mst_pmdn <- function(nu,
                                                 gamma_u,
                                                 device,
-                                                cache = NULL) {
+                                                cache = NULL,
+                                                cache_key = NULL,
+                                                component_u = NULL) {
   B <- nu$size(1)
   S <- nu$size(2)
   normal <- nu == Inf
@@ -164,26 +180,53 @@ latent_draws_mst_pmdn <- function(num_samples = 4096L,
   }
 
   nu_safe <- torch_where(normal, 2 * torch_ones_like(nu), nu)
-  nu_key <- as.numeric(torch::as_array(nu$to(device = "cpu")))
+  bounds <- .uniform_probability_bounds_mst_pmdn(gamma_u$dtype)
   gamma_key <- as.numeric(torch::as_array(gamma_u$to(device = "cpu")))
-  gamma_key <- pmin(
-    pmax(gamma_key, .Machine$double.xmin),
-    1 - .Machine$double.eps
-  )
+  gamma_key <- pmin(pmax(gamma_key, bounds["lower"]), bounds["upper"])
+  component_key <- if (is.null(component_u)) {
+    NULL
+  } else {
+    as.numeric(torch::as_array(component_u$to(device = "cpu")))
+  }
+
   entries <- if (is.environment(cache) &&
                  is.list(cache$gamma_scale_entries)) {
     cache$gamma_scale_entries
   } else {
     list()
   }
+  if (is.environment(cache)) {
+    same_bank <- identical(cache$gamma_scale_gamma_u, gamma_key) &&
+      identical(cache$gamma_scale_component_u, component_key)
+    if (!same_bank) {
+      entries <- list()
+      cache$gamma_scale_entries <- entries
+      cache$gamma_scale_gamma_u <- gamma_key
+      cache$gamma_scale_component_u <- component_key
+    }
+  }
+
+  expanded_nu_key <- if (is.null(cache_key)) {
+    as.numeric(torch::as_array(nu$to(device = "cpu")))
+  } else {
+    NULL
+  }
   hit <- which(vapply(entries, function(entry) {
     identical(entry$dim, c(B, S)) &&
-      identical(entry$nu, nu_key) &&
-      identical(entry$gamma_u, gamma_key)
+      (if (is.null(cache_key)) {
+        is.null(entry$cache_key) &&
+          identical(entry$expanded_nu, expanded_nu_key)
+      } else {
+        identical(entry$cache_key, cache_key)
+      })
   }, logical(1)))[1L]
 
   if (length(hit) && !is.na(hit)) {
     chi2_r <- entries[[hit]]$chi2
+    # Recently used chunks stay resident when the memory limit is reached.
+    entry <- entries[[hit]]
+    entries <- c(entries[-hit], list(entry))
+    cache$gamma_scale_entries <- entries
     cache$gamma_scale_hits <- if (is.null(cache$gamma_scale_hits)) {
       1L
     } else {
@@ -196,18 +239,20 @@ latent_draws_mst_pmdn <- function(num_samples = 4096L,
     if (is.environment(cache)) {
       entries[[length(entries) + 1L]] <- list(
         dim = c(B, S),
-        nu = nu_key,
-        gamma_u = gamma_key,
+        cache_key = cache_key,
+        expanded_nu = expanded_nu_key,
         chi2 = chi2_r
       )
-      # Shapley evaluation repeatedly visits only a few df states. Bound both
-      # entry count and all retained numeric elements so caching cannot defeat
-      # the functional evaluator's memory budget during a long ALE calculation.
-      while (length(entries) > 8L ||
-             (length(entries) > 1L && sum(vapply(
+      # Compact pre-gather pi/nu keys let repeated functionals reuse every
+      # prediction chunk. The element budget, rather than a small entry cap,
+      # remains the binding memory safeguard.
+      bank_elements <- length(gamma_key) + length(component_key)
+      while (length(entries) > 64L ||
+             (length(entries) > 1L && bank_elements + sum(vapply(
                entries,
                function(entry) {
-                 length(entry$nu) + length(entry$gamma_u) +
+                 length(entry$expanded_nu) +
+                   .cache_key_elements_mst_pmdn(entry$cache_key) +
                    length(entry$chi2)
                },
                integer(1)
@@ -249,11 +294,20 @@ latent_draws_mst_pmdn <- function(num_samples = 4096L,
   mu_s <- mu$gather(2L, idx_d)
   chol_s <- scale_chol$gather(2L, idx_dd)
   nu_s <- nu$gather(2L, idx)
+  gamma_cache_key <- list(
+    dim = c(B, S),
+    pi_dim = as.integer(pi$size()),
+    nu_dim = as.integer(nu$size()),
+    pi = as.numeric(torch::as_array(pi$to(device = "cpu"))),
+    nu = as.numeric(torch::as_array(nu$to(device = "cpu")))
+  )
   W <- .gamma_scale_from_uniform_mst_pmdn(
     nu_s,
     latent_draws$gamma_u,
     device = device,
-    cache = latent_draws$.cache
+    cache = latent_draws$.cache,
+    cache_key = gamma_cache_key,
+    component_u = latent_draws$component_u
   )$unsqueeze(3L)
 
   z1 <- latent_draws$skew_z$unsqueeze(1L)$expand(c(B, S, d))

--- a/README.md
+++ b/README.md
@@ -458,7 +458,7 @@ The deep MST-PMDN implementation consists of the following key functions and mod
 
 *   **Purpose:** Define and evaluate one scalar scientific summary per prediction row.
 *   **Method:** Means, variances, standard deviations, covariance, and correlation use exact component and mixture moments, including between-component covariance. Quantiles, marginal and joint exceedances, tail spread, and normalized generalized Bowley tail asymmetry use a parameter-independent latent bank created by `latent_draws_mst_pmdn()`.
-*   **Diagnostics:** Tail summaries report the expected number of Monte Carlo draws in the relevant tail and flag inadequate resolution. Mixture results separately retain expected component draw counts; because component uniforms are shared across rows, component-selection Monte Carlo error does not average away along an effect curve. Exact moments return undefined values when finite degrees of freedom do not support them.
+*   **Diagnostics:** Tail summaries report the expected number of Monte Carlo draws in the relevant tail and flag inadequate resolution. Every public interpretation call aggregates its internal evaluations and emits at most one classed tail-resolution warning; the per-evaluation distribution remains available in diagnostics. Mixture results separately retain expected component draw counts; because component uniforms are shared across rows, component-selection Monte Carlo error does not average away along an effect curve. Exact moments return undefined values when finite degrees of freedom do not support them.
 
 #### Functions: `ale_mst_pmdn(...)` and `ice_mst_pmdn(...)`
 
@@ -469,13 +469,14 @@ The deep MST-PMDN implementation consists of the following key functions and mod
 #### Functions: `image_contrast_mst_pmdn(...)` and `image_occlusion_mst_pmdn(...)`
 
 *   **Purpose:** Measure whole-image and spatial patch effects on the same scalar functionals used by the tabular layer.
-*   **Method:** Observed image regions are replaced by a required reference field, optionally with cosine tapering and overlapping patches. When an input channel is deterministically derived from another, a `rebuild_channels` callback should perturb the fundamental physical field, recompute every linked channel such as a pressure gradient, apply the original preprocessing, and return a complete model-ready tensor.
-*   **Interpretation:** Patch effects are spatial sensitivity measures. They do not generally add across overlapping patches to the whole-image contrast.
+*   **Method:** Observed image regions are replaced by a required reference field, optionally with cosine tapering and overlapping patches. Named `channel_groups` can attribute fields separately; `NULL` retains a joint synoptic-state perturbation. When an input channel is deterministically derived from another, a `rebuild_channels` callback should perturb the fundamental physical field, recompute every linked channel such as a pressure gradient, apply the original preprocessing, and return a complete model-ready tensor. Callback masks have one channel for a joint perturbation and the full model channel count under grouping.
+*   **Monte Carlo stability:** `image_occlusion_mst_pmdn()` accepts multiple independent latent banks, computes every CNN prediction once, and repeats only functional sampling. It returns bank-specific effects, their spread, and a strict same-sign indicator. The indicator is a sign-stability heuristic rather than a confidence interval.
+*   **Interpretation:** Patch effects are spatial sensitivity measures. Cosine taper weights are reported as metadata but do not define a linear normalization through the nonlinear network and functional. Raw effects are retained, and they do not generally add across overlapping patches to the whole-image contrast.
 
 #### Function: `decompose_mst_pmdn(...)`
 
 *   **Purpose:** For one-component models, allocate a known functional contrast among location, complete scale, skewness, and degrees-of-freedom channels.
-*   **Method:** Exact Shapley averaging evaluates all hybrid parameter states—16 when all four channels are active—and reports the numerical sum-to-total residual. Structurally inactive or unchanged channels disappear automatically. The complete Cholesky factor is the scale block; because it maps standardized skew direction into response space, its contribution includes the induced rotation of that direction.
+*   **Method:** Exact Shapley averaging evaluates all hybrid parameter states—16 when all four channels are active—and reports the numerical sum-to-total residual. Structurally inactive or exactly unchanged channels disappear automatically; structural symmetry and an exactly zero skew vector are treated as the same endpoint. Diagnostics report the maximum location, Cholesky-factor, skew-vector, and inverse-df change. The complete Cholesky factor is the scale block; because it maps standardized skew direction into response space, its contribution includes the induced rotation of that direction.
 *   **Scope:** This is parameter-channel attribution rather than feature SHAP. Full channel decomposition is disabled for mixtures because component labels and compensating component changes are not identified.
 
 #### Function: `tail_components_mst_pmdn(...)`

--- a/examples/wave-surge-xai.R
+++ b/examples/wave-surge-xai.R
@@ -48,6 +48,8 @@ main <- function() {
     "surge_lag1"
   )
   num_samples <- 8192L
+  min_tail_draws <- 20L
+  n_occlusion_banks <- 3L
   n_ale_bins <- 12L
   n_ice_grid_points <- 25L
   n_ice_display_curves <- 40L
@@ -442,15 +444,53 @@ main <- function() {
     device = device,
     seed = xai_seed
   )
+  occlusion_banks <- c(
+    list(latent_bank),
+    lapply(seq_len(n_occlusion_banks - 1L), function(replicate) {
+      latent_draws_mst_pmdn(
+        num_samples = num_samples,
+        output_dim = n_response,
+        dtype = pred_test$mu$dtype,
+        device = device,
+        seed = xai_seed + 1000L * replicate
+      )
+    })
+  )
+  report_tail_resolution <- function(label, values) {
+    values <- values[is.finite(values)]
+    if (!length(values)) return(invisible(NULL))
+    probabilities <- c(0, 0.1, 0.25, 0.5, 0.75, 0.9, 1)
+    quantiles <- stats::quantile(
+      values,
+      probs = probabilities,
+      names = FALSE,
+      type = 7
+    )
+    cat(
+      sprintf(
+        paste0(
+          "%s tail draws: n=%d; below %d=%d; ",
+          "q[0,10,25,50,75,90,100]=%s\n"
+        ),
+        label,
+        length(values),
+        min_tail_draws,
+        sum(values < min_tail_draws),
+        paste(format(quantiles, digits = 4), collapse = ",")
+      )
+    )
+    invisible(quantiles)
+  }
   evaluate_functional <- function(functional) {
-    suppressWarnings(functional_mst_pmdn(
+    functional_mst_pmdn(
       pred = pred_test,
       functional = functional,
       latent_draws = latent_bank,
       chunk_size = chunk_size,
       device = device,
-      response_names = response_names
-    ))
+      response_names = response_names,
+      min_tail_draws = min_tail_draws
+    )
   }
 
   cat("Evaluating predictive functionals...\n")
@@ -492,17 +532,23 @@ main <- function() {
       functional_results$surge_skew_direction$data$value
   }
 
-  low_resolution <- vapply(
-    functional_results,
-    function(result) sum(result$data$low_tail_resolution, na.rm = TRUE),
-    integer(1)
-  )
-  low_resolution <- low_resolution[low_resolution > 0L]
-  if (length(low_resolution)) {
+  for (name in names(functional_results)) {
+    report_tail_resolution(
+      paste("Functional", name),
+      functional_results[[name]]$data$expected_tail_draws
+    )
+  }
+  if (!is.null(latent_bank$.cache$gamma_scale_misses)) {
     cat(
-      "Low Monte Carlo tail resolution rows:",
-      paste(names(low_resolution), low_resolution, sep = "=", collapse = ", "),
-      "\n"
+      sprintf(
+        "Finite-df Gamma cache: %d misses, %d hits.\n",
+        latent_bank$.cache$gamma_scale_misses,
+        if (is.null(latent_bank$.cache$gamma_scale_hits)) {
+          0L
+        } else {
+          latent_bank$.cache$gamma_scale_hits
+        }
+      )
     )
   }
 
@@ -638,7 +684,12 @@ main <- function() {
       latent_draws = latent_bank,
       chunk_size = chunk_size,
       device = device,
-      response_names = response_names
+      response_names = response_names,
+      min_tail_draws = min_tail_draws
+    )
+    report_tail_resolution(
+      paste("ALE", feature),
+      ale_model_scale$diagnostics$min_expected_tail_draws_by_bin
     )
     ice_model_scale <- ice_mst_pmdn(
       model = model,
@@ -652,7 +703,8 @@ main <- function() {
       latent_draws = latent_bank,
       chunk_size = chunk_size,
       device = device,
-      response_names = response_names
+      response_names = response_names,
+      min_tail_draws = min_tail_draws
     )
     ale_results[[feature]] <- physicalize_ale(ale_model_scale, feature)
     ice_results[[feature]] <- physicalize_ice(ice_model_scale, feature)
@@ -685,7 +737,8 @@ main <- function() {
     latent_draws = latent_bank,
     chunk_size = chunk_size,
     device = device,
-    response_names = response_names
+    response_names = response_names,
+    min_tail_draws = min_tail_draws
   )
   image_contrast$data$date <- test_dates[image_contrast$data$case]
 
@@ -700,12 +753,28 @@ main <- function() {
     stride = stride,
     cases = occlusion_cases,
     taper = "cosine",
-    channel_groups = NULL,
+    channel_groups = list(psl = 1L, uas = 2L, vas = 3L),
     decompose = FALSE,
-    latent_draws = latent_bank,
+    latent_draws = occlusion_banks,
     chunk_size = chunk_size,
     device = device,
-    response_names = response_names
+    response_names = response_names,
+    min_tail_draws = min_tail_draws
+  )
+  report_tail_resolution(
+    "Image occlusion",
+    image_occlusion$diagnostics$min_expected_tail_draws_by_evaluation
+  )
+  cat(
+    sprintf(
+      "Population occlusion signs stable across %d banks: %d/%d patches.\n",
+      n_occlusion_banks,
+      sum(
+        image_occlusion$population$mc_mean_signed_effect_sign_stable,
+        na.rm = TRUE
+      ),
+      nrow(image_occlusion$population)
+    )
   )
   image_occlusion$data$date <- test_dates[image_occlusion$data$case]
 
@@ -713,15 +782,16 @@ main <- function() {
   tail_components <- list()
   if (n_mixtures > 1L) {
     cat("Computing surge tail-component accounting...\n")
-    tail_components$surge <- suppressWarnings(tail_components_mst_pmdn(
+    tail_components$surge <- tail_components_mst_pmdn(
       pred = pred_test,
       response = 2L,
       threshold = model_threshold[2L],
       latent_draws = latent_bank,
       chunk_size = chunk_size,
       device = device,
-      response_names = response_names
-    ))
+      response_names = response_names,
+      min_tail_draws = min_tail_draws
+    )
     tail_components$surge$data$date <-
       test_dates[tail_components$surge$data$row]
   }
@@ -750,15 +820,16 @@ main <- function() {
       image_inputs = x_image_test[extreme_case, , , , drop = FALSE],
       device = device
     )
-    case_decomposition <- suppressWarnings(decompose_mst_pmdn(
+    case_decomposition <- decompose_mst_pmdn(
       pred_from = pred_typical,
       pred_to = pred_extreme,
       functional = joint_event,
       latent_draws = latent_bank,
       chunk_size = 1L,
       device = device,
-      response_names = response_names
-    ))
+      response_names = response_names,
+      min_tail_draws = min_tail_draws
+    )
   }
 
   # The plotting methods do not require the latent bank. Release these
@@ -779,6 +850,18 @@ main <- function() {
   tail_components <- lapply(tail_components, compact_object)
   case_decomposition <- compact_object(case_decomposition)
 
+  image_occlusion_plot <- image_occlusion
+  unstable_case <- is.na(image_occlusion_plot$data$mc_sign_stable) |
+    !image_occlusion_plot$data$mc_sign_stable
+  image_occlusion_plot$data$effect[unstable_case] <- NA_real_
+  population_sign_stable <-
+    image_occlusion_plot$population$mc_mean_signed_effect_sign_stable
+  unstable_population <- is.na(population_sign_stable) |
+    !population_sign_stable
+  image_occlusion_plot$population$mean_signed_effect[
+    unstable_population
+  ] <- NA_real_
+
   finite_limit <- function(values, absolute = FALSE, fallback = 1 / num_samples) {
     values <- values[is.finite(values)]
     if (!length(values)) return(fallback)
@@ -787,21 +870,19 @@ main <- function() {
   }
   occlusion_plot_limits <- list(
     case_effect = rep(
-      c(-1, 1) * finite_limit(image_occlusion$data$effect, absolute = TRUE),
-      length.out = 2L
-    ),
-    mean_signed_effect = rep(
       c(-1, 1) * finite_limit(
-        image_occlusion$population$mean_signed_effect,
+        image_occlusion_plot$data$effect,
         absolute = TRUE
       ),
       length.out = 2L
     ),
-    mean_absolute_effect = c(
-      0,
-      finite_limit(image_occlusion$population$mean_absolute_effect)
-    ),
-    positive_fraction = c(0, 1)
+    mean_signed_effect = rep(
+      c(-1, 1) * finite_limit(
+        image_occlusion_plot$population$mean_signed_effect,
+        absolute = TRUE
+      ),
+      length.out = 2L
+    )
   )
 
   pdf_device <- if (capabilities("cairo")) {
@@ -819,6 +900,11 @@ main <- function() {
   col_surge <- "#D55E00"
   col_joint <- "#009E73"
   col_dependence <- "#CC79A7"
+  occlusion_group_labels <- c(
+    psl = "Sea-level pressure",
+    uas = "Zonal wind",
+    vas = "Meridional wind"
+  )
   channel_labels <- c(
     location = "Location",
     scale = "Scale",
@@ -1410,148 +1496,127 @@ main <- function() {
   }
 
   graphics::layout(
-    matrix(c(1:6, rep(7L, 3L)), nrow = 3L, byrow = TRUE),
-    heights = c(3.8, 0.75, 1.7)
+    matrix(c(1L, 2L, 3L, 4L, 4L, 4L), nrow = 2L, byrow = TRUE),
+    heights = c(4, 0.8)
   )
   population_map_mar <- c(3.1, 4, 2.4, 0.6)
   graphics::par(
-    mar = population_map_mar,
-    oma = c(0.2, 0, 2.2, 0),
+    oma = c(2.8, 0, 2.2, 0),
     mgp = c(2.1, 0.55, 0),
     cex.axis = 0.78,
     cex.lab = 0.8,
     cex.main = 0.82,
     pty = "s"
   )
-  plot(
-    image_occlusion,
-    statistic = "mean_signed_effect",
-    xlab = "Array column",
-    ylab = "Array row",
-    main = "Mean signed effect",
-    col = diverging_palette,
-    zlim = occlusion_plot_limits$mean_signed_effect,
-    useRaster = FALSE
-  )
-  graphics::par(mar = population_map_mar, pty = "s")
-  plot(
-    image_occlusion,
-    statistic = "mean_absolute_effect",
-    xlab = "Array column",
-    ylab = "",
-    main = "Mean absolute effect",
-    col = absolute_palette,
-    zlim = occlusion_plot_limits$mean_absolute_effect,
-    useRaster = FALSE
-  )
-  graphics::par(mar = population_map_mar, pty = "s")
-  plot(
-    image_occlusion,
-    statistic = "positive_fraction",
-    xlab = "Array column",
-    ylab = "",
-    main = "Fraction supporting risk",
-    col = diverging_palette,
-    zlim = occlusion_plot_limits$positive_fraction,
-    useRaster = FALSE
-  )
-  draw_horizontal_colour_key(
-    occlusion_plot_limits$mean_signed_effect,
-    diverging_palette,
-    "Mean signed effect"
-  )
-  draw_horizontal_colour_key(
-    occlusion_plot_limits$mean_absolute_effect,
-    absolute_palette,
-    "Mean absolute effect"
-  )
-  draw_horizontal_colour_key(
-    occlusion_plot_limits$positive_fraction,
-    diverging_palette,
-    "Positive-effect fraction"
-  )
-  graphics::par(mar = rep(0, 4), pty = "m")
-  graphics::plot.new()
-  graphics::text(
-    0.5,
-    0.65,
-    sprintf(
-      "Joint psl/uas/vas occlusion; %d x %d patch; stride %d x %d.",
-      patch_size[1L], patch_size[2L], stride[1L], stride[2L]
-    ),
-    cex = 0.82
-  )
-  graphics::text(
-    0.5,
-    0.38,
-    paste(
-      "Effect = original minus patch-occluded; positive means the",
-      "observed patch supports risk."
-    ),
-    cex = 0.78
-  )
-  graphics::mtext(
-    "Population summaries across selected high-risk cases",
-    side = 3,
-    outer = TRUE,
-    line = 0.5,
-    cex = 1.05
-  )
-  graphics::layout(matrix(1L, nrow = 1L))
-
-  graphics::layout(matrix(seq_len(6L), nrow = 2L, byrow = TRUE))
-  individual_map_mar <- c(3.2, 4, 2.3, 0.6)
-  graphics::par(
-    oma = c(2.8, 0, 2.2, 0),
-    mgp = c(2.1, 0.55, 0),
-    cex.axis = 0.76,
-    cex.lab = 0.8,
-    cex.main = 0.82
-  )
-  for (i in seq_along(occlusion_cases)) {
-    case <- occlusion_cases[i]
-    panel_row <- if (i <= 3L) 1L else 2L
-    panel_column <- if (i <= 3L) i else i - 3L
-    graphics::par(
-      mar = individual_map_mar,
-      pty = "s"
-    )
+  for (group_name in names(image_occlusion$channel_groups)) {
+    graphics::par(mar = population_map_mar, pty = "s")
     plot(
-      image_occlusion,
-      case = case,
-      statistic = "effect",
-      xlab = if (panel_row == 2L) "Array column" else "",
-      ylab = if (panel_column == 1L) "Array row" else "",
-      main = format(test_dates[case]),
+      image_occlusion_plot,
+      group = group_name,
+      statistic = "mean_signed_effect",
+      xlab = "Array column",
+      ylab = if (group_name == names(
+        image_occlusion$channel_groups
+      )[1L]) {
+        "Array row"
+      } else {
+        ""
+      },
+      main = unname(occlusion_group_labels[group_name]),
       col = diverging_palette,
-      zlim = occlusion_plot_limits$case_effect,
+      zlim = occlusion_plot_limits$mean_signed_effect,
       useRaster = FALSE
     )
   }
-  draw_vertical_colour_key(
-    occlusion_plot_limits$case_effect,
+  draw_horizontal_colour_key(
+    occlusion_plot_limits$mean_signed_effect,
     diverging_palette,
-    "Probability effect (original - occluded)",
-    compact = TRUE
+    "Mean probability effect (original - occluded)"
   )
   graphics::mtext(
-    "Individual joint-channel occlusion maps: highest-risk cases",
+    "Field-specific population occlusion: selected high-risk cases",
     side = 3,
     outer = TRUE,
     line = 0.5,
     cex = 1.05
   )
   graphics::mtext(
-    paste(
-      "All panels share one scale; red supports risk and blue suppresses it.",
-      "Axes follow the saved array orientation."
+    sprintf(
+      paste0(
+        "Common scale; blank patches changed sign across %d banks. ",
+        "Cosine %d x %d patches have mean mask weight %.3f."
+      ),
+      n_occlusion_banks,
+      patch_size[1L],
+      patch_size[2L],
+      mean(image_occlusion$patches$mask_mean)
     ),
     side = 1,
     outer = TRUE,
-    line = 0.5,
-    cex = 0.75
+    line = 0.6,
+    cex = 0.74
   )
   graphics::layout(matrix(1L, nrow = 1L))
+
+  individual_map_mar <- c(3.2, 4, 2.3, 0.6)
+  for (group_name in names(image_occlusion$channel_groups)) {
+    graphics::layout(matrix(seq_len(6L), nrow = 2L, byrow = TRUE))
+    graphics::par(
+      oma = c(2.8, 0, 2.2, 0),
+      mgp = c(2.1, 0.55, 0),
+      cex.axis = 0.76,
+      cex.lab = 0.8,
+      cex.main = 0.82
+    )
+    for (i in seq_along(occlusion_cases)) {
+      case <- occlusion_cases[i]
+      panel_row <- if (i <= 3L) 1L else 2L
+      panel_column <- if (i <= 3L) i else i - 3L
+      graphics::par(
+        mar = individual_map_mar,
+        pty = "s"
+      )
+      plot(
+        image_occlusion_plot,
+        case = case,
+        group = group_name,
+        statistic = "effect",
+        xlab = if (panel_row == 2L) "Array column" else "",
+        ylab = if (panel_column == 1L) "Array row" else "",
+        main = format(test_dates[case]),
+        col = diverging_palette,
+        zlim = occlusion_plot_limits$case_effect,
+        useRaster = FALSE
+      )
+    }
+    draw_vertical_colour_key(
+      occlusion_plot_limits$case_effect,
+      diverging_palette,
+      "Probability effect (original - occluded)",
+      compact = TRUE
+    )
+    graphics::mtext(
+      paste(
+        unname(occlusion_group_labels[group_name]),
+        "occlusion: highest-risk cases"
+      ),
+      side = 3,
+      outer = TRUE,
+      line = 0.5,
+      cex = 1.05
+    )
+    graphics::mtext(
+      paste(
+        "All fields and cases share one scale; blank patches changed sign",
+        sprintf("across %d independent latent banks.", n_occlusion_banks)
+      ),
+      side = 1,
+      outer = TRUE,
+      line = 0.5,
+      cex = 0.75
+    )
+    graphics::layout(matrix(1L, nrow = 1L))
+  }
 
   if (!is.null(case_decomposition)) {
     active_channels <- case_decomposition$active_channels

--- a/examples/wave-surge-xai.R
+++ b/examples/wave-surge-xai.R
@@ -717,8 +717,9 @@ main <- function() {
 
   # Each psl/uas/vas field was standardized grid cell by grid cell. A zero
   # model-scale reference is therefore the physical training climatology.
-  # There are no deterministically derived image channels, so all three source
-  # fields can be blended jointly without a rebuild_channels callback.
+  # There are no deterministically derived image channels, so no
+  # rebuild_channels callback is needed. The whole-image contrast blends the
+  # three fields jointly; spatial occlusion attributes them separately.
   reference_images <- array(
     0,
     dim = c(1L, image_dimensions[2:4]),

--- a/man/ale_mst_pmdn.Rd
+++ b/man/ale_mst_pmdn.Rd
@@ -20,7 +20,8 @@ ale_mst_pmdn(
   seed = NULL,
   chunk_size = NULL,
   device = "cpu",
-  response_names = NULL
+  response_names = NULL,
+  min_tail_draws = 20L
 )
 }
 \arguments{
@@ -41,6 +42,9 @@ ale_mst_pmdn(
   \item{chunk_size}{Optional prediction and functional case chunk size.}
   \item{device}{Torch evaluation device.}
   \item{response_names}{Optional prediction response names.}
+  \item{min_tail_draws}{Warning threshold for expected draws in an evaluated
+  tail. Internal endpoint and hybrid warnings are aggregated into one warning
+  from this call.}
 }
 \details{
 ALE replaces a feature by its lower and upper empirical-bin boundaries only
@@ -50,8 +54,9 @@ centred. The midpoint value subtracts half of the current bin effect, a
 within-bin linear interpolation convention rather than the boundary-valued
 definition in Apley and Zhu. This makes ALE the preferred population summary
 when meteorological predictors are correlated. For Monte Carlo functionals,
-diagnostics report the minimum expected tail-draw count actually encountered at
-the evaluated bin endpoints or hybrid parameter states.
+diagnostics report the distribution of expected tail-draw counts encountered
+at evaluated bin endpoints or hybrid parameter states. One classed summary
+warning is emitted when any evaluation falls below \code{min_tail_draws}.
 }
 \value{
 An \code{mst_pmdn_ale} object with \code{data}, breaks, settings, and

--- a/man/decompose_mst_pmdn.Rd
+++ b/man/decompose_mst_pmdn.Rd
@@ -17,7 +17,8 @@ decompose_mst_pmdn(
   seed = NULL,
   chunk_size = NULL,
   device = "cpu",
-  response_names = NULL
+  response_names = NULL,
+  min_tail_draws = 20L
 )
 }
 \arguments{
@@ -32,6 +33,8 @@ decompose_mst_pmdn(
   \item{chunk_size}{Optional case chunk size.}
   \item{device}{Torch evaluation device.}
   \item{response_names}{Optional prediction response names.}
+  \item{min_tail_draws}{Warning threshold for expected draws in an evaluated
+  tail. Hybrid-state warnings are aggregated into one warning.}
 }
 \details{
 Every hybrid prediction takes each selected parameter block from
@@ -43,8 +46,11 @@ direction in response space; the scale channel therefore includes that induced
 directional change as well as marginal scale and dependence. This is
 parameter-channel attribution, not feature SHAP.
 
-Unchanged channels, exact fixed degrees of freedom, and structural zero
-skewness disappear automatically. Full decomposition is rejected for mixtures
+Unchanged channels, exact fixed degrees of freedom, and effective symmetry
+(either structural zero skewness or exactly zero \eqn{\alpha}) disappear
+automatically. Diagnostics report maximum absolute endpoint changes in
+location, the Cholesky scale factor, \eqn{\alpha}, and inverse degrees of
+freedom. Full decomposition is rejected for mixtures
 because head labels and compensating component changes are not identified.
 }
 \value{

--- a/man/functional_mst_pmdn.Rd
+++ b/man/functional_mst_pmdn.Rd
@@ -53,5 +53,7 @@ Tail asymmetry is normalized by its selected interquantile spread and is thus
 dimensionless. Common component uniforms deliberately correlate Monte Carlo
 error across prediction rows. Expected tail draws diagnose only the complete
 marginal functional; expected component draw counts are retained separately for
-mixtures.
+mixtures. Low-resolution results emit a classed
+\code{mst_pmdn_tail_resolution_warning}; the numerical values and diagnostics
+are still returned.
 }

--- a/man/ice_mst_pmdn.Rd
+++ b/man/ice_mst_pmdn.Rd
@@ -11,6 +11,7 @@ ice_mst_pmdn(
   grid = NULL,
   reference = NULL,
   n_curves = 100L,
+  cases = NULL,
   ale = TRUE,
   n_bins = 20L,
   num_samples = 4096L,
@@ -18,18 +19,22 @@ ice_mst_pmdn(
   seed = NULL,
   chunk_size = NULL,
   device = "cpu",
-  response_names = NULL
+  response_names = NULL,
+  min_tail_draws = 20L
 )
 }
 \arguments{
   \item{model,inputs,feature,functional,image_inputs,num_samples,latent_draws,
-  seed,chunk_size,device,response_names}{As in
+  seed,chunk_size,device,response_names,min_tail_draws}{As in
   \code{\link{ale_mst_pmdn}}.}
   \item{grid}{Optional increasing feature grid. The default is 25 empirical
   quantiles from 0.05 through 0.95.}
   \item{reference}{Feature value at which every curve is centred. The default
   is the empirical median.}
-  \item{n_curves}{Maximum number of evenly spaced input cases.}
+  \item{n_curves}{Maximum number of systematically spaced input cases when
+  \code{cases} is \code{NULL}.}
+  \item{cases}{Optional explicit R 1-based case indices. When supplied,
+  \code{n_curves} is ignored.}
   \item{ale}{\code{TRUE} to compute an ALE overlay using all input rows,
   \code{FALSE} or \code{NULL} to omit it, or a matching precomputed
   \code{mst_pmdn_ale} object.}
@@ -43,7 +48,10 @@ An object of class \code{mst_pmdn_ice} with a plain \code{curves} data frame
 and an optional \code{mst_pmdn_ale} object.
 }
 \details{
-The same latent bank is used at every grid point. Fixed-reference ICE is
+The same latent bank is used at every grid point. The default grid deliberately
+stays within the empirical 5th--95th percentile range to avoid emphasizing
+extreme predictor combinations; an explicit grid can include the endpoints.
+Fixed-reference ICE is
 intended to show effect heterogeneity and interactions; unlike ALE, it can
 construct predictor combinations with weak empirical support.
 The default overlay requires a separate full-data ALE calculation; it can be

--- a/man/ice_mst_pmdn.Rd
+++ b/man/ice_mst_pmdn.Rd
@@ -11,7 +11,6 @@ ice_mst_pmdn(
   grid = NULL,
   reference = NULL,
   n_curves = 100L,
-  cases = NULL,
   ale = TRUE,
   n_bins = 20L,
   num_samples = 4096L,
@@ -20,6 +19,7 @@ ice_mst_pmdn(
   chunk_size = NULL,
   device = "cpu",
   response_names = NULL,
+  cases = NULL,
   min_tail_draws = 20L
 )
 }

--- a/man/image_contrast_mst_pmdn.Rd
+++ b/man/image_contrast_mst_pmdn.Rd
@@ -21,7 +21,8 @@ image_contrast_mst_pmdn(
   seed = NULL,
   chunk_size = NULL,
   device = "cpu",
-  response_names = NULL
+  response_names = NULL,
+  min_tail_draws = 20L
 )
 }
 \arguments{
@@ -44,6 +45,8 @@ image_contrast_mst_pmdn(
   \item{chunk_size}{Optional prediction and functional case chunk size.}
   \item{device}{Torch evaluation device.}
   \item{response_names}{Optional prediction response names.}
+  \item{min_tail_draws}{Warning threshold for expected draws in an evaluated
+  tail. Internal functional warnings are aggregated into one warning.}
 }
 \details{
 The contrast is the functional under the observed image minus the functional

--- a/man/image_occlusion_mst_pmdn.Rd
+++ b/man/image_occlusion_mst_pmdn.Rd
@@ -21,13 +21,18 @@ image_occlusion_mst_pmdn(
   seed = NULL,
   chunk_size = NULL,
   device = "cpu",
-  response_names = NULL
+  response_names = NULL,
+  min_tail_draws = 20L
 )
 }
 \arguments{
   \item{model,inputs,image_inputs,reference_images,functional,cases,
-  rebuild_channels,decompose,channels,num_samples,latent_draws,seed,chunk_size,
-  device,response_names}{As in \code{\link{image_contrast_mst_pmdn}}.}
+  rebuild_channels,decompose,channels,num_samples,seed,chunk_size,
+  device,response_names,min_tail_draws}{As in
+  \code{\link{image_contrast_mst_pmdn}}.}
+  \item{latent_draws}{One common latent bank, or a non-empty list of
+  independent banks with equal draw counts. Patch predictions are computed
+  once and reused across banks.}
   \item{patch_size}{Two positive integers giving patch rows and columns. This
   is required because a scientifically appropriate spatial scale is
   application dependent.}
@@ -43,16 +48,29 @@ minus occluded changes in a scalar predictive functional.
 }
 \value{
 An object of class \code{mst_pmdn_image_occlusion}. It contains case-level
-patch effects, population mean signed effect, mean absolute effect, positive-
-effect frequency, patch geometry, spatial coverage, optional one-component
-parameter-channel maps, and numerical closure residuals.
+patch effects and bank-replicate effects, population summaries, between-bank
+spread and sign-stability diagnostics, patch geometry and taper weights,
+binary and weighted spatial coverage, optional one-component parameter-channel
+maps, and numerical closure residuals.
 }
 \details{
 The callback can perturb a scientifically fundamental field, recompute linked
 channels such as pressure gradients, apply original preprocessing, and return
-the complete model-ready tensor. Rebuilt original and occluded states must
-have matching shapes, representations, dtypes, and devices. Overlapping patch
-effects are spatial sensitivity measures: parameter channels sum within each
-patch, but effects generally do not sum across patches to the whole-image
-contrast.
+the complete model-ready tensor. With \code{channel_groups = NULL}, callback
+masks have shape \code{[case, 1, row, column]}; grouped masks have the full
+\code{[case, channel, row, column]} shape. Rebuilt original and occluded states
+must have matching shapes, representations, dtypes, and devices.
+
+Cosine tapering changes the input perturbation and is not interpreted as a
+fixed fraction of full occlusion. Raw effects are retained; \code{mask_sum},
+\code{mask_mean}, and \code{mask_max} describe patch strength. Binary
+\code{coverage} counts overlapping patch rectangles, while
+\code{weighted_coverage} sums taper weights.
+
+With multiple latent banks, \code{effect} is their mean and replicate values
+are retained separately. A sign is marked stable only when every bank-specific
+effect lies strictly on the same side of zero. This is a Monte Carlo
+sign-stability heuristic, not a confidence interval. Overlapping patch effects
+are spatial sensitivity measures: parameter channels sum within each patch,
+but effects generally do not sum across patches to the whole-image contrast.
 }

--- a/man/latent_draws_mst_pmdn.Rd
+++ b/man/latent_draws_mst_pmdn.Rd
@@ -34,7 +34,11 @@ component-selection error does not average away along an ALE curve. Functional
 tail-draw diagnostics describe the marginal event or quantile; mixture
 diagnostics separately report expected component draw counts.
 Finite-df evaluations may attach a bounded, mutable Gamma-quantile cache to the
-bank supplied by the caller. Public functional and explanation result objects
+bank supplied by the caller. Compact pre-gather mixture-weight and
+degrees-of-freedom keys permit chunk reuse across related functionals while a
+fixed retained-element budget bounds memory. Endpoint uniforms are clamped at
+dtype-appropriate half-quantum bounds before Gamma inversion. Public functional
+and explanation result objects
 retain the latent tensors needed for exact reproduction but omit this cache, so
 serializing a result does not retain cached chi-square arrays.
 }

--- a/man/tail_components_mst_pmdn.Rd
+++ b/man/tail_components_mst_pmdn.Rd
@@ -31,7 +31,9 @@ tail_components_mst_pmdn(
   \item{chunk_size}{Optional case chunk size.}
   \item{device}{Torch evaluation device.}
   \item{response_names}{Optional prediction response names.}
-  \item{min_tail_draws}{Warning threshold for expected mixture-tail draws.}
+  \item{min_tail_draws}{Warning threshold for expected mixture and
+  within-component tail draws. Internal warnings are aggregated into one
+  classed summary warning.}
 }
 \details{
 For component \eqn{g}, the output reports \eqn{p_g=P_g(Y>u)}, weighted

--- a/tests/testthat/test-explain-channels.R
+++ b/tests/testthat/test-explain-channels.R
@@ -127,7 +127,7 @@ test_that("structural and numerical symmetry are the same inactive endpoint", {
   expect_length(result$active_channels, 0L)
   expect_equal(result$data$total, 0, tolerance = 0)
   expect_equal(
-    result$diagnostics$parameter_change_magnitudes["skewness"],
+    unname(result$diagnostics$parameter_change_magnitudes["skewness"]),
     0,
     tolerance = 0
   )
@@ -153,5 +153,8 @@ test_that("decomposition emits one classed tail-resolution summary", {
   expect_length(warnings, 1L)
   expect_s3_class(warnings[[1L]], "mst_pmdn_tail_resolution_warning")
   expect_equal(result$diagnostics$min_expected_tail_draws, 0)
-  expect_equal(result$diagnostics$parameter_change_magnitudes["location"], 1)
+  expect_equal(
+    unname(result$diagnostics$parameter_change_magnitudes["location"]),
+    1
+  )
 })

--- a/tests/testthat/test-explain-channels.R
+++ b/tests/testthat/test-explain-channels.R
@@ -113,3 +113,45 @@ test_that("full parameter-channel decomposition rejects mixtures", {
     "only available for M = 1"
   )
 })
+
+
+test_that("structural and numerical symmetry are the same inactive endpoint", {
+  pair <- make_channel_pair(alpha_from = 0, alpha_to = 0)
+  pair$from$skew_none <- TRUE
+  pair$to$skew_none <- FALSE
+  result <- decompose_mst_pmdn(
+    pair$from,
+    pair$to,
+    mst_functional("mean", 1L)
+  )
+  expect_length(result$active_channels, 0L)
+  expect_equal(result$data$total, 0, tolerance = 0)
+  expect_equal(
+    result$diagnostics$parameter_change_magnitudes["skewness"],
+    0,
+    tolerance = 0
+  )
+})
+
+test_that("decomposition emits one classed tail-resolution summary", {
+  pair <- make_channel_pair(mu_to = 1, skew_none = TRUE)
+  bank <- latent_draws_mst_pmdn(32L, output_dim = 1L, seed = 82)
+  warnings <- list()
+  result <- withCallingHandlers(
+    decompose_mst_pmdn(
+      pair$from,
+      pair$to,
+      mst_functional("exceedance", 1L, threshold = 100),
+      latent_draws = bank,
+      min_tail_draws = 2L
+    ),
+    mst_pmdn_tail_resolution_warning = function(condition) {
+      warnings[[length(warnings) + 1L]] <<- condition
+      invokeRestart("muffleWarning")
+    }
+  )
+  expect_length(warnings, 1L)
+  expect_s3_class(warnings[[1L]], "mst_pmdn_tail_resolution_warning")
+  expect_equal(result$diagnostics$min_expected_tail_draws, 0)
+  expect_equal(result$diagnostics$parameter_change_magnitudes["location"], 1)
+})

--- a/tests/testthat/test-explain-effects.R
+++ b/tests/testthat/test-explain-effects.R
@@ -49,13 +49,16 @@ test_that("ALE tail diagnostics use evaluated event probabilities", {
     "exceedance", 1L, threshold = 10, direction = "upper"
   )
   bank <- latent_draws_mst_pmdn(128L, output_dim = 1L, seed = 22)
-  result <- ale_mst_pmdn(
-    model,
-    x,
-    1L,
-    functional,
-    n_bins = 5L,
-    latent_draws = bank
+  expect_warning(
+    result <- ale_mst_pmdn(
+      model,
+      x,
+      1L,
+      functional,
+      n_bins = 5L,
+      latent_draws = bank
+    ),
+    class = "mst_pmdn_tail_resolution_warning"
   )
   expect_equal(result$diagnostics$min_expected_tail_draws, 0)
   expect_equal(
@@ -252,5 +255,63 @@ test_that("channel-specific ALE closes to the total effect", {
     result$data$sum_to_total_residual,
     rep(0, nrow(result$data)),
     tolerance = 1e-7
+  )
+})
+
+
+test_that("ICE accepts explicit one-based cases", {
+  x <- cbind(feature = seq(-1, 1, length.out = 10), other = 0)
+  result <- ice_mst_pmdn(
+    explanation_test_model(slope = 2),
+    x,
+    feature = 1L,
+    functional = mst_functional("mean", 1L),
+    grid = c(-1, 0, 1),
+    cases = c(2L, 7L, 10L),
+    ale = FALSE
+  )
+  expect_identical(result$cases, c(2L, 7L, 10L))
+  expect_identical(result$settings$case_selection, "explicit")
+  expect_identical(unique(result$curves$case), c(2L, 7L, 10L))
+  expect_error(
+    ice_mst_pmdn(
+      explanation_test_model(),
+      x,
+      1L,
+      mst_functional("mean", 1L),
+      grid = c(-1, 1),
+      cases = 0L,
+      ale = FALSE
+    ),
+    "1-based"
+  )
+})
+
+test_that("ICE aggregates tail-resolution warnings across its evaluations", {
+  x <- cbind(feature = seq(-1, 1, length.out = 6), other = 0)
+  bank <- latent_draws_mst_pmdn(32L, output_dim = 1L, seed = 83)
+  warnings <- list()
+  result <- withCallingHandlers(
+    ice_mst_pmdn(
+      explanation_test_model(),
+      x,
+      feature = 1L,
+      functional = mst_functional("exceedance", 1L, threshold = 100),
+      grid = c(-1, 1),
+      cases = c(1L, 6L),
+      ale = FALSE,
+      latent_draws = bank,
+      min_tail_draws = 2L
+    ),
+    mst_pmdn_tail_resolution_warning = function(condition) {
+      warnings[[length(warnings) + 1L]] <<- condition
+      invokeRestart("muffleWarning")
+    }
+  )
+  expect_length(warnings, 1L)
+  expect_identical(result$diagnostics$tail_resolution_evaluations, 3L)
+  expect_identical(
+    result$diagnostics$low_tail_resolution_evaluations,
+    3L
   )
 })

--- a/tests/testthat/test-explain-images.R
+++ b/tests/testthat/test-explain-images.R
@@ -202,3 +202,196 @@ test_that("image decomposition rejects mixtures before patch evaluation", {
     "only available for M = 1"
   )
 })
+
+
+test_that("occlusion reports taper strength and weighted coverage", {
+  x <- matrix(0, nrow = 1, ncol = 1)
+  image <- array(1, c(1, 1, 4, 4))
+  reference <- array(0, c(1, 1, 4, 4))
+  result <- image_occlusion_mst_pmdn(
+    explanation_test_model(slope = 0, image_channel = 1L),
+    x,
+    image,
+    reference,
+    mst_functional("mean", 1L),
+    patch_size = c(2L, 2L),
+    stride = c(2L, 2L),
+    taper = "cosine"
+  )
+  expect_true(all(result$patches$mask_sum > 0))
+  expect_true(all(result$patches$mask_mean < 1))
+  expect_true(all(result$patches$mask_max < 1))
+  expect_equal(
+    sum(result$weighted_coverage),
+    sum(result$patches$mask_sum),
+    tolerance = 1e-12
+  )
+  expect_true(all(result$coverage == 1))
+})
+
+test_that("channel-group occlusion works for arrays and torch tensors", {
+  x <- matrix(0, nrow = 1, ncol = 1)
+  image_array <- array(0, c(1, 2, 2, 2))
+  image_array[, 1L, , ] <- 1
+  image_array[, 2L, , ] <- 4
+  reference_array <- array(0, c(1, 2, 2, 2))
+  model <- explanation_test_model(slope = 0, image_channel = 2L)
+
+  for (tensor_input in c(FALSE, TRUE)) {
+    image <- if (tensor_input) {
+      torch::torch_tensor(image_array)
+    } else {
+      image_array
+    }
+    reference <- if (tensor_input) {
+      torch::torch_tensor(reference_array)
+    } else {
+      reference_array
+    }
+    result <- image_occlusion_mst_pmdn(
+      model,
+      x,
+      image,
+      reference,
+      mst_functional("mean", 1L),
+      patch_size = c(2L, 2L),
+      stride = c(2L, 2L),
+      taper = "none",
+      channel_groups = list(first = 1L, second = 2L)
+    )
+    expect_identical(result$data$group, c("first", "second"))
+    expect_equal(result$data$effect, c(0, 4), tolerance = 1e-6)
+  }
+})
+
+test_that("replicate occlusion reuses predictions and exposes bank spread", {
+  x <- matrix(0, nrow = 1, ncol = 1)
+  image <- array(2, c(1, 1, 2, 2))
+  reference <- array(0, c(1, 1, 2, 2))
+  banks <- lapply(84:86, function(seed) {
+    latent_draws_mst_pmdn(64L, output_dim = 1L, seed = seed)
+  })
+  result <- image_occlusion_mst_pmdn(
+    explanation_test_model(slope = 0, image_channel = 1L),
+    x,
+    image,
+    reference,
+    mst_functional("exceedance", 1L, threshold = 1),
+    patch_size = c(2L, 2L),
+    stride = c(2L, 2L),
+    taper = "none",
+    latent_draws = banks,
+    min_tail_draws = 1L
+  )
+  expect_identical(result$settings$mc_replicates, 3L)
+  expect_equal(nrow(result$replicate_data), 3L)
+  expect_equal(
+    result$data$effect,
+    mean(result$replicate_data$effect),
+    tolerance = 0
+  )
+  expect_equal(
+    result$population$mc_mean_signed_effect_min,
+    min(result$population_replicate$mean_signed_effect),
+    tolerance = 0
+  )
+  expect_length(result$latent_draws, 3L)
+  expect_true(all(vapply(
+    result$latent_draws,
+    function(bank) !".cache" %in% names(bank),
+    logical(1)
+  )))
+})
+
+test_that("image entry points emit one classed resolution warning per call", {
+  x <- matrix(0, nrow = 1, ncol = 1)
+  image <- array(1, c(1, 1, 1, 1))
+  reference <- array(0, c(1, 1, 1, 1))
+  model <- explanation_test_model(slope = 0, image_channel = 1L)
+  functional <- mst_functional("exceedance", 1L, threshold = 100)
+  bank <- latent_draws_mst_pmdn(32L, output_dim = 1L, seed = 87)
+
+  capture_call <- function(expr) {
+    warnings <- list()
+    value <- withCallingHandlers(
+      expr,
+      mst_pmdn_tail_resolution_warning = function(condition) {
+        warnings[[length(warnings) + 1L]] <<- condition
+        invokeRestart("muffleWarning")
+      }
+    )
+    list(value = value, warnings = warnings)
+  }
+  contrast <- capture_call(image_contrast_mst_pmdn(
+    model,
+    x,
+    image,
+    reference,
+    functional,
+    latent_draws = bank,
+    min_tail_draws = 2L
+  ))
+  occlusion <- capture_call(image_occlusion_mst_pmdn(
+    model,
+    x,
+    image,
+    reference,
+    functional,
+    patch_size = c(1L, 1L),
+    stride = c(1L, 1L),
+    taper = "none",
+    latent_draws = bank,
+    min_tail_draws = 2L
+  ))
+  expect_length(contrast$warnings, 1L)
+  expect_length(occlusion$warnings, 1L)
+  expect_s3_class(
+    occlusion$warnings[[1L]],
+    "mst_pmdn_tail_resolution_warning"
+  )
+})
+
+
+test_that("grouped callbacks receive full-channel masks", {
+  x <- matrix(0, nrow = 1, ncol = 1)
+  image_array <- array(1, c(1, 2, 1, 1))
+  reference_array <- array(0, c(1, 2, 1, 1))
+
+  for (tensor_input in c(FALSE, TRUE)) {
+    mask_channels <- integer(0)
+    rebuild <- function(base_images, reference_images, masks,
+                        case_index = NULL) {
+      shape <- if (inherits(masks, "torch_tensor")) {
+        as.integer(masks$size())
+      } else {
+        dim(masks)
+      }
+      mask_channels <<- c(mask_channels, shape[2L])
+      (1 - masks) * base_images + masks * reference_images
+    }
+    image <- if (tensor_input) {
+      torch::torch_tensor(image_array)
+    } else {
+      image_array
+    }
+    reference <- if (tensor_input) {
+      torch::torch_tensor(reference_array)
+    } else {
+      reference_array
+    }
+    image_occlusion_mst_pmdn(
+      explanation_test_model(slope = 0, image_channel = 2L),
+      x,
+      image,
+      reference,
+      mst_functional("mean", 1L),
+      patch_size = c(1L, 1L),
+      stride = c(1L, 1L),
+      taper = "none",
+      channel_groups = list(first = 1L, second = 2L),
+      rebuild_channels = rebuild
+    )
+    expect_true(length(mask_channels) > 1L)
+    expect_true(all(mask_channels == 2L))
+  }
+})

--- a/tests/testthat/test-explain-mixtures.R
+++ b/tests/testthat/test-explain-mixtures.R
@@ -41,3 +41,44 @@ test_that("tail-component rows retain one-based component identities", {
     tolerance = 1e-8
   )
 })
+
+
+test_that("tail-component accounting preserves prediction response names", {
+  pred <- make_mdn_output(
+    pi = matrix(c(0.4, 0.6), 1, 2),
+    mu = array(c(-1, 0, 1, 2), c(1, 2, 2)),
+    scale_chol = array(
+      rep(diag(2), 2L),
+      c(1, 2, 2, 2)
+    ),
+    nu = matrix(Inf, 1, 2),
+    alpha = array(0, c(1, 2, 2)),
+    skew_none = TRUE
+  )
+  attr(pred, "response_names") <- c("wave", "surge")
+
+  expect_warning(
+    named <- tail_components_mst_pmdn(
+      pred,
+      response = "surge",
+      threshold = 0,
+      num_samples = 256L,
+      seed = 43,
+      min_tail_draws = 1L
+    ),
+    NA
+  )
+  explicit <- tail_components_mst_pmdn(
+    pred,
+    response = 2L,
+    threshold = 0,
+    num_samples = 256L,
+    seed = 43,
+    min_tail_draws = 1L
+  )
+  expect_equal(
+    named$data$component_probability,
+    explicit$data$component_probability,
+    tolerance = 0
+  )
+})

--- a/tests/testthat/test-explain-mixtures.R
+++ b/tests/testthat/test-explain-mixtures.R
@@ -61,7 +61,7 @@ test_that("tail-component accounting preserves prediction response names", {
     named <- tail_components_mst_pmdn(
       pred,
       response = "surge",
-      threshold = 0,
+      threshold = 1.5,
       num_samples = 256L,
       seed = 43,
       min_tail_draws = 1L
@@ -71,7 +71,7 @@ test_that("tail-component accounting preserves prediction response names", {
   explicit <- tail_components_mst_pmdn(
     pred,
     response = 2L,
-    threshold = 0,
+    threshold = 1.5,
     num_samples = 256L,
     seed = 43,
     min_tail_draws = 1L

--- a/tests/testthat/test-explain-mixtures.R
+++ b/tests/testthat/test-explain-mixtures.R
@@ -44,13 +44,13 @@ test_that("tail-component rows retain one-based component identities", {
 
 
 test_that("tail-component accounting preserves prediction response names", {
+  scale_chol <- array(0, c(1, 2, 2, 2))
+  scale_chol[1, 1, , ] <- diag(2)
+  scale_chol[1, 2, , ] <- diag(2)
   pred <- make_mdn_output(
     pi = matrix(c(0.4, 0.6), 1, 2),
     mu = array(c(-1, 0, 1, 2), c(1, 2, 2)),
-    scale_chol = array(
-      rep(diag(2), 2L),
-      c(1, 2, 2, 2)
-    ),
+    scale_chol = scale_chol,
     nu = matrix(Inf, 1, 2),
     alpha = array(0, c(1, 2, 2)),
     skew_none = TRUE

--- a/tests/testthat/test-functionals.R
+++ b/tests/testthat/test-functionals.R
@@ -328,3 +328,37 @@ test_that("probability transforms do not alter tail-resolution diagnostics", {
   expect_equal(result$data$expected_tail_draws, 0)
   expect_equal(result$data$value, stats::qlogis(0.5 / 64))
 })
+
+
+test_that("rare joint exceedance reports its exact Monte Carlo resolution", {
+  pred <- make_mdn_output(
+    pi = matrix(1, 1, 1),
+    mu = array(0, c(1, 1, 2)),
+    scale_chol = array(diag(2), c(1, 1, 2, 2)),
+    nu = matrix(Inf, 1, 1),
+    alpha = array(0, c(1, 1, 2)),
+    skew_none = TRUE
+  )
+  bank <- latent_draws_mst_pmdn(64L, output_dim = 2L, seed = 81)
+  z <- matrix(0, nrow = 64L, ncol = 2L)
+  z[1L, ] <- 3
+  bank$skew_z <- torch::torch_tensor(z, dtype = pred$mu$dtype)
+
+  expect_warning(
+    result <- functional_mst_pmdn(
+      pred,
+      mst_functional(
+        "joint_exceedance",
+        responses = c(1L, 2L),
+        threshold = c(2, 2)
+      ),
+      latent_draws = bank,
+      min_tail_draws = 2L
+    ),
+    class = "mst_pmdn_tail_resolution_warning"
+  )
+  expect_equal(result$data$value, 1 / 64, tolerance = 0)
+  expect_equal(result$data$expected_tail_draws, 1, tolerance = 0)
+  expect_identical(result$diagnostics$low_tail_resolution_count, 1L)
+  expect_identical(result$diagnostics$tail_resolution_evaluations, 1L)
+})

--- a/tests/testthat/test-latent-draws.R
+++ b/tests/testthat/test-latent-draws.R
@@ -204,9 +204,9 @@ test_that("float32 endpoint uniforms produce finite Student-t samples", {
   sampled <- MST.PMDN:::.sample_with_latent_mst_pmdn(pred, bank)
   expect_true(all(is.finite(torch::as_array(sampled$samples))))
   expect_equal(
-    MST.PMDN:::.uniform_probability_bounds_mst_pmdn(
+    unname(MST.PMDN:::.uniform_probability_bounds_mst_pmdn(
       torch::torch_float()
-    )["lower"],
+    )["lower"]),
     2^-25,
     tolerance = 0
   )

--- a/tests/testthat/test-latent-draws.R
+++ b/tests/testthat/test-latent-draws.R
@@ -150,3 +150,64 @@ test_that("latent evaluation supports float32, float64, and conditional CUDA", {
   )
   expect_true(sampled$samples$device$type == "cuda")
 })
+
+
+test_that("finite-df cache retains all chunks across related functionals", {
+  B <- 12L
+  pred <- make_mdn_output(
+    pi = matrix(1, B, 1),
+    mu = array(seq(-1, 1, length.out = B), c(B, 1, 1)),
+    scale_chol = array(1, c(B, 1, 1, 1)),
+    nu = matrix(seq(5, 16, length.out = B), B, 1),
+    alpha = array(0.2, c(B, 1, 1))
+  )
+  bank <- latent_draws_mst_pmdn(64L, output_dim = 1L, seed = 102)
+
+  functional_mst_pmdn(
+    pred,
+    mst_functional("quantile", 1L, prob = 0.5),
+    latent_draws = bank,
+    chunk_size = 1L,
+    min_tail_draws = 1L
+  )
+  expect_equal(bank$.cache$gamma_scale_misses, B)
+  expect_null(bank$.cache$gamma_scale_hits)
+
+  functional_mst_pmdn(
+    pred,
+    mst_functional("exceedance", 1L, threshold = 0),
+    latent_draws = bank,
+    chunk_size = 1L,
+    min_tail_draws = 1L
+  )
+  expect_equal(bank$.cache$gamma_scale_misses, B)
+  expect_equal(bank$.cache$gamma_scale_hits, B)
+})
+
+test_that("float32 endpoint uniforms produce finite Student-t samples", {
+  pred <- make_mdn_output(
+    pi = matrix(1, 2, 1),
+    mu = array(0, c(2, 1, 1)),
+    scale_chol = array(1, c(2, 1, 1, 1)),
+    nu = matrix(c(5, 9), 2, 1),
+    alpha = array(0, c(2, 1, 1)),
+    skew_none = TRUE,
+    dtype = torch::torch_float()
+  )
+  bank <- latent_draws_mst_pmdn(
+    2L, output_dim = 1L, dtype = torch::torch_float(), seed = 103
+  )
+  bank$gamma_u <- torch::torch_tensor(
+    matrix(c(0, 1), ncol = 1L),
+    dtype = torch::torch_float()
+  )
+  sampled <- MST.PMDN:::.sample_with_latent_mst_pmdn(pred, bank)
+  expect_true(all(is.finite(torch::as_array(sampled$samples))))
+  expect_equal(
+    MST.PMDN:::.uniform_probability_bounds_mst_pmdn(
+      torch::torch_float()
+    )["lower"],
+    2^-25,
+    tolerance = 0
+  )
+})


### PR DESCRIPTION
## Summary

- propagate `min_tail_draws` through every public XAI entry point and emit one classed, call-level warning while retaining per-evaluation diagnostics
- preserve prediction response names in component-tail accounting and treat structural symmetry and exact zero skewness as the same decomposition endpoint
- use dtype-aware uniform bounds and compact pre-gather cache keys so finite-df chunks remain reusable across related functionals
- add explicit ICE case indices, taper-weight metadata, weighted coverage, and tested field-group masking for arrays and torch tensors
- let image occlusion accept independent latent-bank replicates, reuse each CNN prediction, and report bank spread plus strict sign stability
- update the wave-surge workflow to separate psl/uas/vas maps, use three independent banks, share colour scales, and mask sign-unstable patches

## Design notes

The between-bank minimum/maximum and same-sign flag are diagnostics, not confidence intervals. Raw cosine-tapered effects are retained without normalization because the CNN and target functional are nonlinear. The qgamma cache keeps the existing two-million-element memory bound; compact keys and a larger nonbinding entry cap allow the 12 wave-surge chunks to remain resident.

## Validation

GitHub Actions R-CMD-check passes with 479 tests passed, 0 failed, 0 warnings, and 3 conditional CUDA skips. R CMD check reports only the two pre-existing NOTEs for `.github` and `LICENSE`.

The added tests cover rare joint-tail resolution, warning aggregation, named responses, float32 endpoint uniforms, cross-functional cache reuse, explicit ICE cases, grouped array/tensor masks, callback mask dimensions, and replicated occlusion outputs. The saved-data wave-surge script is excluded from the package build, so its full model/data-backed PDF run was not executed in CI.