### PR TITLE
Fix decomposed image contrast tail warning

### DIFF
--- a/R/explain-images.R
+++ b/R/explain-images.R
@@ -426,12 +426,10 @@ image_contrast_mst_pmdn <- function(model,
     )
   }
   if (isTRUE(decompose)) {
-    tail_summary <- diagnostics[c(
-      "min_expected_tail_draws",
-      "low_tail_resolution_count",
-      "tail_resolution_evaluations",
-      "low_tail_resolution_evaluations"
-    )]
+    tail_summary <- .tail_resolution_summary_mst_pmdn(
+      list(diagnostics),
+      min_tail_draws
+    )
   }
   .warn_tail_resolution_mst_pmdn(
     tail_summary, "image_contrast_mst_pmdn()"

--- a/tests/testthat/test-explain-images.R
+++ b/tests/testthat/test-explain-images.R
@@ -322,15 +322,18 @@ test_that("image entry points emit one classed resolution warning per call", {
     )
     list(value = value, warnings = warnings)
   }
-  contrast <- capture_call(image_contrast_mst_pmdn(
-    model,
-    x,
-    image,
-    reference,
-    functional,
-    latent_draws = bank,
-    min_tail_draws = 2L
-  ))
+  contrasts <- lapply(c(FALSE, TRUE), function(decompose) {
+    capture_call(image_contrast_mst_pmdn(
+      model,
+      x,
+      image,
+      reference,
+      functional,
+      decompose = decompose,
+      latent_draws = bank,
+      min_tail_draws = 2L
+    ))
+  })
   occlusion <- capture_call(image_occlusion_mst_pmdn(
     model,
     x,
@@ -343,14 +346,25 @@ test_that("image entry points emit one classed resolution warning per call", {
     latent_draws = bank,
     min_tail_draws = 2L
   ))
-  expect_length(contrast$warnings, 1L)
+  expect_true(all(vapply(
+    contrasts,
+    function(item) length(item$warnings) == 1L,
+    logical(1)
+  )))
+  for (contrast in contrasts) {
+    expect_s3_class(
+      contrast$warnings[[1L]],
+      "mst_pmdn_tail_resolution_warning"
+    )
+    expect_identical(contrast$warnings[[1L]]$min_tail_draws, 2L)
+    expect_identical(contrast$value$diagnostics$min_tail_draws, 2L)
+  }
   expect_length(occlusion$warnings, 1L)
   expect_s3_class(
     occlusion$warnings[[1L]],
     "mst_pmdn_tail_resolution_warning"
   )
 })
-
 
 test_that("grouped callbacks receive full-channel masks", {
   x <- matrix(0, nrow = 1, ncol = 1)


### PR DESCRIPTION
## Summary

- normalize the decomposed image-contrast tail-resolution summary before emitting its public warning
- retain the configured `min_tail_draws` in the warning condition and returned diagnostics
- cover under-resolved whole-image contrasts with both `decompose = FALSE` and `decompose = TRUE`

## Failure fixed

Previously, the decomposed wrapper omitted `min_tail_draws` when copying diagnostic fields. That produced a zero-length condition message and the opaque base-R error `bad error message`.

## Validation

GitHub Actions R-CMD-check passes on commit `a7d190e`: 485 tests passed, 0 failed, 0 warnings, and 3 conditional CUDA skips.